### PR TITLE
Add task mapper

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
@@ -9,6 +9,7 @@ kt_jvm_library(
     name = "exchangetasks",
     srcs = glob(["*.kt"]),
     deps = [
+        "//src/main/kotlin/org/wfanet/panelmatch/client/storage",
         "//src/main/kotlin/org/wfanet/panelmatch/protocol/common:commutativeencryption",
         "//src/main/kotlin/org/wfanet/panelmatch/protocol/common:protocolutils",
         "//src/main/proto/wfa/measurement/api/v2alpha:exchange_step_attempts_service_kt_jvm_grpc",

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskMapper.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskMapper.kt
@@ -1,0 +1,96 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.exchangetasks
+
+import com.google.protobuf.ByteString
+import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow
+import org.wfanet.panelmatch.client.storage.Storage
+
+/**
+ * Maps ExchangeWorkflow.Step to respective tasks. Stores inputs and outputs.
+ *
+ * @param ExchangeWorkflow.Step to execute.
+ * @param input inputs needed by all [task]s.
+ * @param sendDebugLog function which writes logs happened during execution.
+ * @return Executed output. It is a map from the labels to the payload associated with the label.
+ */
+class ExchangeTaskMapper {
+
+  suspend fun execute(
+    step: ExchangeWorkflow.Step,
+    input: Map<String, ByteString>,
+    storageClass: Storage,
+    sendDebugLog: suspend (String) -> Unit
+  ): ByteString? {
+    val inputLabels = step.getInputLabelsMap()
+    val outputLabels = step.getOutputLabelsMap()
+    val outputFieldName = requireNotNull(outputLabels["output"])
+    val storage = storageClass
+    when (step.getStepCase()) {
+      ExchangeWorkflow.Step.StepCase.INPUT -> {
+        val inputFieldName = requireNotNull(inputLabels["input"])
+        storage.write(outputFieldName, requireNotNull(input[inputFieldName]))
+        return null
+      }
+      // TODO split this up into encrypt and reencrypt
+      ExchangeWorkflow.Step.StepCase.ENCRYPT_AND_SHARE -> {
+        when (step.encryptAndShare.getInputFormat()) {
+          ExchangeWorkflow.Step.EncryptAndShareStep.InputFormat.PLAINTEXT -> {
+            val taskInput: Map<String, ByteString> =
+              mapOf(
+                "encryption-key" to storage.read(requireNotNull(inputLabels["crypto-key"])),
+                "unencrypted-data" to storage.read(requireNotNull(inputLabels["unencrypted-data"]))
+              )
+            val taskOutput = EncryptTask().execute(taskInput, sendDebugLog)
+            val encryptedData = requireNotNull(taskOutput["encrypted-data"])
+            // TODO store data in shared location or send to Measurement Coordinator
+            storage.write(outputFieldName, encryptedData)
+            return encryptedData
+          }
+          ExchangeWorkflow.Step.EncryptAndShareStep.InputFormat.CIPHERTEXT -> {
+            val taskInput: Map<String, ByteString> =
+              mapOf(
+                "encryption-key" to storage.read(requireNotNull(inputLabels["crypto-key"])),
+                "encrypted-data" to storage.read(requireNotNull(inputLabels["encrypted-data"]))
+              )
+            val taskOutput = ReEncryptTask().execute(taskInput, sendDebugLog)
+            val reencryptedData = requireNotNull(taskOutput["reencrypted-data"])
+            // TODO store data in shared location or send to Measurement Coordinator
+            storage.write(outputFieldName, reencryptedData)
+            return reencryptedData
+          }
+          else -> {
+            error("Unsupported encryption type")
+          }
+        }
+      }
+      ExchangeWorkflow.Step.StepCase.DECRYPT -> {
+        val taskInput: Map<String, ByteString> =
+          mapOf(
+            "encryption-key" to storage.read(requireNotNull(inputLabels["crypto-key"])),
+            "encrypted-data" to storage.read(requireNotNull(inputLabels["encrypted-data"]))
+          )
+        val taskOutput = ReEncryptTask().execute(taskInput, sendDebugLog)
+        val decryptedData = requireNotNull(taskOutput["reencrypted-data"])
+        // TODO store data in shared location or send to Measurement Coordinator
+        storage.write(outputFieldName, decryptedData)
+        return decryptedData
+      }
+      else -> {
+        error("Unsupported step for Model Provider")
+      }
+    }
+  }
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskMapper.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskMapper.kt
@@ -19,25 +19,26 @@ import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow
 import org.wfanet.panelmatch.client.storage.Storage
 
 /**
- * Maps ExchangeWorkflow.Step to respective tasks. Stores inputs and outputs.
+ * Maps ExchangeWorkflow.Step to respective tasks. Retrieves necessary inputs. Executes step. Stores
+ * outputs.
  *
  * @param ExchangeWorkflow.Step to execute.
  * @param input inputs needed by all [task]s.
+ * @param storage the Storage class to store the intermediary steps
  * @param sendDebugLog function which writes logs happened during execution.
- * @return Executed output. It is a map from the labels to the payload associated with the label.
+ * @return mapped output. This is either a ByteString or null for input steps.
  */
 class ExchangeTaskMapper {
 
   suspend fun execute(
     step: ExchangeWorkflow.Step,
     input: Map<String, ByteString>,
-    storageClass: Storage,
+    storage: Storage,
     sendDebugLog: suspend (String) -> Unit
   ): ByteString? {
     val inputLabels = step.getInputLabelsMap()
     val outputLabels = step.getOutputLabelsMap()
     val outputFieldName = requireNotNull(outputLabels["output"])
-    val storage = storageClass
     when (step.getStepCase()) {
       ExchangeWorkflow.Step.StepCase.INPUT -> {
         val inputFieldName = requireNotNull(inputLabels["input"])
@@ -89,7 +90,7 @@ class ExchangeTaskMapper {
         return decryptedData
       }
       else -> {
-        error("Unsupported step for Model Provider")
+        error("Unsupported step type")
       }
     }
   }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepValidator.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepValidator.kt
@@ -16,11 +16,8 @@ package org.wfanet.panelmatch.client.launcher
 
 import org.wfanet.measurement.api.v2alpha.ExchangeStep
 
-/** Indicates that an [ExchangeStep] is not valid to execute. */
-class InvalidExchangeStepException(message: String) : Exception(message)
-
 /** Determines whether an ExchangeStep is valid and can be safely executed. */
 interface ExchangeStepValidator {
-  /** Throws [InvalidExchangeStepException] if [exchangeStep] is invalid. */
-  @Throws(InvalidExchangeStepException::class) fun validate(exchangeStep: ExchangeStep)
+  /** Returns [bool] if [exchangeStep] is invalid. */
+  bool fun validate(exchangeStep: ExchangeStep)
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/BUILD.bazel
@@ -1,9 +1,7 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 load("@wfa_measurement_system//build:defs.bzl", "test_target")
 
-package(default_visibility = [
-    test_target(":__subpackages__"),
-])
+package(default_visibility = ["//visibility:public"])
 
 kt_jvm_library(
     name = "storage",

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/InMemoryStorage.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/InMemoryStorage.kt
@@ -16,15 +16,19 @@ package org.wfanet.panelmatch.client.storage
 
 import com.google.protobuf.ByteString
 
-/** Interface for InputReader adapter. */
-interface InputReader {
+/**
+ * Stores everything in memory. Nothing is persistent. Use with caution. Uses a simple hashmap to
+ * storage everything where path is the key.
+ */
+class InMemoryStorage : Storage {
+  private var inMemoryStorage = HashMap<String, ByteString>()
+  constructor() {}
 
-  /**
-   * Reads input data from given path.
-   *
-   * @param path String location of input data to read from.
-   * @return Input data.
-   * @throws IOException
-   */
-  suspend fun read(path: String): ByteString
+  override suspend fun read(path: String): ByteString {
+    return requireNotNull(inMemoryStorage[path])
+  }
+
+  override suspend fun write(path: String, data: ByteString) {
+    inMemoryStorage.put(path, data)
+  }
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/Storage.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/Storage.kt
@@ -16,14 +16,21 @@ package org.wfanet.panelmatch.client.storage
 
 import com.google.protobuf.ByteString
 
-/** Interface for OutputWriter adapter. */
-interface OutputWriter {
+/** Interface for Storage adapter. */
+interface Storage {
+
+  /**
+   * Reads input data from given path.
+   *
+   * @param path String location of input data to read from.
+   * @return Input data.
+   */
+  suspend fun read(path: String): ByteString
 
   /**
    * Writes output data into given path.
    *
    * @param path String location of data to write to.
-   * @throws IOException
    */
   suspend fun write(path: String, data: ByteString)
 }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
 
 kt_jvm_test(
-    name = "ExchangeTasksTest",
-    srcs = ["ExchangeTasksTest.kt"],
-    test_class = "org.wfanet.panelmatch.client.exchangetasks.ExchangeTasksTest",
+    name = "ExchangeTaskTest",
+    srcs = ["ExchangeTaskTest.kt"],
+    test_class = "org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskTest",
     deps = [
         "//src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks",
         "//src/main/proto/wfanet/panelmatch/protocol/exchangesteps:exchangesteps_java_proto",
@@ -13,5 +13,21 @@ kt_jvm_test(
         "@wfa_measurement_system//imports/kotlin/com/nhaarman/mockitokotlin2",
         "@wfa_measurement_system//imports/kotlin/kotlin/test",
         "@wfa_measurement_system//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
+    ],
+)
+
+kt_jvm_test(
+    name = "ExchangeTaskMapperTest",
+    srcs = ["ExchangeTaskMapperTest.kt"],
+    test_class = "org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskMapperTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/storage",
+        "//src/main/kotlin/org/wfanet/panelmatch/protocol/common:protocolutils",
+        "@wfa_measurement_system//imports/java/com/google/common/truth",
+        "@wfa_measurement_system//imports/java/com/google/common/truth/extensions/proto",
+        "@wfa_measurement_system//imports/java/org/junit",
+        "@wfa_measurement_system//imports/kotlin/com/nhaarman/mockitokotlin2",
+        "@wfa_measurement_system//imports/kotlin/kotlin/test",
     ],
 )

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskMapperTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskMapperTest.kt
@@ -1,0 +1,151 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.exchangetasks
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.ByteString
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow
+import org.wfanet.panelmatch.client.storage.*
+import org.wfanet.panelmatch.protocol.common.applyCommutativeEncryption
+import org.wfanet.panelmatch.protocol.common.makeSerializedSharedInputs
+import org.wfanet.panelmatch.protocol.common.parseSerializedSharedInputs
+import org.wfanet.panelmatch.protocol.common.reApplyCommutativeEncryption
+
+@RunWith(JUnit4::class)
+class ExchangeTaskMapperTest {
+  private val DP_0_SECRET_KEY = ByteString.copyFromUtf8("random-edp-string-0")
+  private val MP_0_SECRET_KEY = ByteString.copyFromUtf8("random-mp-string-0")
+  private val joinkeys =
+    listOf<ByteString>(
+      ByteString.copyFromUtf8("some joinkey0"),
+      ByteString.copyFromUtf8("some joinkey1"),
+      ByteString.copyFromUtf8("some joinkey2"),
+      ByteString.copyFromUtf8("some joinkey3"),
+      ByteString.copyFromUtf8("some joinkey4")
+    )
+  private val fakeSendDebugLog: suspend (String) -> Unit = {}
+  private suspend fun executeStepConfig(
+    stepConfig: Map<String, Any>,
+    storage: Storage
+  ): ByteString? {
+    var step = ExchangeWorkflow.Step.newBuilder()
+    val inputLabels = requireNotNull(stepConfig["inputLabels"]) as Map<String, String>
+    val outputLabels = requireNotNull(stepConfig["outputLabels"]) as Map<String, String>
+    step =
+      when (stepConfig["stepType"]) {
+        ExchangeWorkflow.Step.StepCase.INPUT ->
+          step.apply { input = ExchangeWorkflow.Step.InputStep.getDefaultInstance() }
+        ExchangeWorkflow.Step.StepCase.ENCRYPT_AND_SHARE ->
+          step.apply {
+            encryptAndShare =
+              ExchangeWorkflow.Step.EncryptAndShareStep.newBuilder()
+                .apply {
+                  inputFormat =
+                    stepConfig["inputFormat"] as
+                      ExchangeWorkflow.Step.EncryptAndShareStep.InputFormat
+                }
+                .build()
+          }
+        ExchangeWorkflow.Step.StepCase.DECRYPT ->
+          step.apply { decrypt = ExchangeWorkflow.Step.DecryptStep.getDefaultInstance() }
+        else -> throw Exception("Unsupported step config")
+      }
+    val builtStep = step.putAllInputLabels(inputLabels).putAllOutputLabels(outputLabels).build()
+    return ExchangeTaskMapper()
+      .execute(
+        builtStep,
+        stepConfig["inputData"] as Map<String, ByteString>,
+        storage,
+        fakeSendDebugLog
+      )
+  }
+  @Test
+  fun `test single party initiating steps for both parties in shared memory`() = runBlocking {
+    val storage = InMemoryStorage()
+    val stepsConfig =
+      listOf(
+        mapOf(
+          "inputLabels" to mapOf("input" to "crypto-key"),
+          "outputLabels" to mapOf("output" to "mp-crypto-key"),
+          "stepType" to ExchangeWorkflow.Step.StepCase.INPUT,
+          "inputData" to mapOf("crypto-key" to MP_0_SECRET_KEY)
+        ),
+        mapOf(
+          "inputLabels" to mapOf("input" to "crypto-key"),
+          "outputLabels" to mapOf("output" to "dp-crypto-key"),
+          "stepType" to ExchangeWorkflow.Step.StepCase.INPUT,
+          "inputData" to mapOf("crypto-key" to DP_0_SECRET_KEY)
+        ),
+        mapOf(
+          "inputLabels" to mapOf("input" to "joinkeys"),
+          "outputLabels" to mapOf("output" to "mp-joinkeys"),
+          "stepType" to ExchangeWorkflow.Step.StepCase.INPUT,
+          "inputData" to mapOf("joinkeys" to makeSerializedSharedInputs(joinkeys))
+        ),
+        mapOf(
+          "inputLabels" to
+            mapOf("crypto-key" to "mp-crypto-key", "unencrypted-data" to "mp-joinkeys"),
+          "outputLabels" to mapOf("output" to "mp-single-blinded-joinkeys"),
+          "stepType" to ExchangeWorkflow.Step.StepCase.ENCRYPT_AND_SHARE,
+          "inputFormat" to ExchangeWorkflow.Step.EncryptAndShareStep.InputFormat.PLAINTEXT,
+          "inputData" to emptyMap<String, ByteString>()
+        ),
+        mapOf(
+          "inputLabels" to
+            mapOf(
+              "crypto-key" to "dp-crypto-key",
+              "encrypted-data" to "mp-single-blinded-joinkeys"
+            ),
+          "outputLabels" to mapOf("output" to "dp-mp-double-blinded-joinkeys"),
+          "stepType" to ExchangeWorkflow.Step.StepCase.ENCRYPT_AND_SHARE,
+          "inputFormat" to ExchangeWorkflow.Step.EncryptAndShareStep.InputFormat.CIPHERTEXT,
+          "inputData" to emptyMap<String, ByteString>()
+        ),
+        mapOf(
+          "inputLabels" to
+            mapOf(
+              "crypto-key" to "mp-crypto-key",
+              "encrypted-data" to "dp-mp-double-blinded-joinkeys"
+            ),
+          "outputLabels" to mapOf("output" to "decrypted-data"),
+          "stepType" to ExchangeWorkflow.Step.StepCase.DECRYPT,
+          "inputData" to emptyMap<String, ByteString>()
+        )
+      )
+    val stepOutputs = mutableListOf<ByteString?>()
+    for (stepConfig in stepsConfig) {
+      stepOutputs.add(executeStepConfig(stepConfig, storage))
+    }
+
+    // Verify single blinded output
+    val encryptedJoinKeys = applyCommutativeEncryption(MP_0_SECRET_KEY, joinkeys)
+    assertThat(encryptedJoinKeys)
+      .isEqualTo(parseSerializedSharedInputs(requireNotNull(stepOutputs[3])))
+
+    // Verify double blinded output
+    val reEncryptedJoinKeys = reApplyCommutativeEncryption(DP_0_SECRET_KEY, encryptedJoinKeys)
+    assertThat(reEncryptedJoinKeys)
+      .isEqualTo(parseSerializedSharedInputs(requireNotNull(stepOutputs[4])))
+
+    // Verify decrypted double blinded output
+    val decryptedJoinKeys = reApplyCommutativeEncryption(MP_0_SECRET_KEY, reEncryptedJoinKeys)
+    assertThat(decryptedJoinKeys)
+      .isEqualTo(parseSerializedSharedInputs(requireNotNull(stepOutputs[5])))
+  }
+}

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskTest.kt
@@ -27,7 +27,7 @@ import org.wfanet.panelmatch.protocol.common.reApplyCommutativeEncryption
 import wfanet.panelmatch.protocol.protobuf.SharedInputs
 
 @RunWith(JUnit4::class)
-class ExchangeTasksTest {
+class ExchangeTaskTest {
   private val joinKeys =
     listOf<ByteString>(
       ByteString.copyFromUtf8("some key0"),

--- a/src/test/kotlin/org/wfanet/panelmatch/client/storage/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/storage/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "StorageTest",
+    srcs = ["StorageTest.kt"],
+    test_class = "org.wfanet.panelmatch.client.storage.StorageTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/panelmatch/client/storage",
+        "//src/main/proto/wfanet/panelmatch/protocol/exchangesteps:exchangesteps_java_proto",
+        "@wfa_measurement_system//imports/java/com/google/common/truth",
+        "@wfa_measurement_system//imports/java/com/google/common/truth/extensions/proto",
+        "@wfa_measurement_system//imports/java/org/junit",
+        "@wfa_measurement_system//imports/kotlin/com/nhaarman/mockitokotlin2",
+        "@wfa_measurement_system//imports/kotlin/kotlin/test",
+        "@wfa_measurement_system//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/panelmatch/client/storage/StorageTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/storage/StorageTest.kt
@@ -1,0 +1,41 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.storage
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.ByteString
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+class StorageTest {
+
+  @Test
+  fun `write and read inMemoryStorage`() = runBlocking {
+    val valueToStore = ByteString.copyFromUtf8("random-edp-string-0")
+    val key = "some-key"
+    val storage = InMemoryStorage()
+    storage.write(key, valueToStore)
+    assertThat(storage.read(key)).isEqualTo(valueToStore)
+  }
+
+  @Test
+  fun `get error for invalid key from inMemoryStorage`() = runBlocking {
+    val valueToStore = ByteString.copyFromUtf8("random-edp-string-0")
+    val key = "some-key"
+    val storage = InMemoryStorage()
+    val reencryptException = assertFailsWith(IllegalArgumentException::class) { storage.read(key) }
+  }
+}


### PR DESCRIPTION
Adds a task mapper to work through an example workflow
See https://github.com/world-federation-of-advertisers/cross-media-measurement-api/blob/0e1c9d33776d02527820181712d8dc289abc0b7c/docs/panelmatch/example-exchange-workflow.textproto for an example
 * Maps ExchangeWorkflow.Step to respective tasks. 
 * Retrieves necessary inputs. 
 * Executes step. 
 * Stores outputs.