### PR TITLE
Add Kotlin-friendly Apache Beam utility library

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -131,6 +131,7 @@ MAVEN_ARTIFACTS.update({
     "org.apache.beam:beam-sdks-java-core": "2.29.0",
     "org.hamcrest:hamcrest-library": "1.3",
     "org.hamcrest:hamcrest-core": "1.3",
+    "org.slf4j:slf4j-simple": "1.7.9",
 })
 
 maven_install(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -129,6 +129,8 @@ MAVEN_ARTIFACTS.update({
     "junit:junit": "4.13",
     "org.apache.beam:beam-runners-direct-java": "2.29.0",
     "org.apache.beam:beam-sdks-java-core": "2.29.0",
+    "org.hamcrest:hamcrest-library": "1.3",
+    "org.hamcrest:hamcrest-core": "1.3",
 })
 
 maven_install(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -127,6 +127,8 @@ MAVEN_ARTIFACTS.update({
     "com.nhaarman.mockitokotlin2:mockito-kotlin": "2.2.0",
     "info.picocli:picocli": "4.4.0",
     "junit:junit": "4.13",
+    "org.apache.beam:beam-runners-direct-java": "2.29.0",
+    "org.apache.beam:beam-sdks-java-core": "2.29.0",
 })
 
 maven_install(

--- a/imports/java/com/google/common/BUILD.bazel
+++ b/imports/java/com/google/common/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "guava",
+    actual = "@maven//:com_google_guava_guava",
+)

--- a/imports/java/org/apache/beam/BUILD.bazel
+++ b/imports/java/org/apache/beam/BUILD.bazel
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "core",
+    actual = "@maven//:org_apache_beam_beam_sdks_java_core",
+)
+
+alias(
+    name = "direct_runner",
+    actual = "@maven//:org_apache_beam_beam_runners_direct_java",
+)

--- a/imports/java/org/hamcrest/BUILD.bazel
+++ b/imports/java/org/hamcrest/BUILD.bazel
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "core",
+    actual = "@maven//:org_hamcrest_hamcrest_core",
+)
+
+alias(
+    name = "library",
+    actual = "@maven//:org_hamcrest_hamcrest_library",
+)

--- a/imports/java/org/slf4j/BUILD.bazel
+++ b/imports/java/org/slf4j/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+alias(
+    name = "simple",
+    actual = "@maven//:org_slf4j_slf4j_simple",
+)

--- a/src/main/kotlin/org/wfanet/panelmatch/common/beam/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/beam/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+package(default_visibility = [
+    "//src/main/kotlin/org/wfanet/panelmatch:__subpackages__",
+    "//src/test/kotlin/org/wfanet/panelmatch:__subpackages__",
+])
+
+kt_jvm_library(
+    name = "beam",
+    srcs = glob(["*.kt"]),
+    deps = [
+        "//imports/java/com/google/common:guava",
+        "//imports/java/org/apache/beam:core",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/panelmatch/common/beam/Beam.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/beam/Beam.kt
@@ -21,6 +21,7 @@ import org.apache.beam.sdk.transforms.Flatten
 import org.apache.beam.sdk.transforms.Keys
 import org.apache.beam.sdk.transforms.ParDo
 import org.apache.beam.sdk.transforms.Partition
+import org.apache.beam.sdk.transforms.SerializableFunction
 import org.apache.beam.sdk.transforms.Values
 import org.apache.beam.sdk.transforms.join.CoGroupByKey
 import org.apache.beam.sdk.transforms.join.KeyedPCollectionTuple
@@ -134,4 +135,10 @@ inline fun <InT, reified SideT, reified OutT> PCollection<InT>.parDoWithSideInpu
       }
     }
   return ParDo.of(doFn).withSideInputs(sideInput).expand(this)
+}
+
+inline fun <KeyT, reified ValueT> PCollection<KV<KeyT, ValueT>>.combinePerKey(
+  crossinline block: (Iterable<ValueT>) -> ValueT
+): PCollection<KV<KeyT, ValueT>> {
+  return Combine.perKey<KeyT, ValueT>(SerializableFunction { block(it) }).expand(this)
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/common/beam/Beam.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/beam/Beam.kt
@@ -1,0 +1,119 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.common.beam
+
+import org.apache.beam.sdk.transforms.Combine
+import org.apache.beam.sdk.transforms.Count
+import org.apache.beam.sdk.transforms.DoFn
+import org.apache.beam.sdk.transforms.Flatten
+import org.apache.beam.sdk.transforms.Keys
+import org.apache.beam.sdk.transforms.ParDo
+import org.apache.beam.sdk.transforms.Partition
+import org.apache.beam.sdk.transforms.join.CoGroupByKey
+import org.apache.beam.sdk.transforms.join.KeyedPCollectionTuple
+import org.apache.beam.sdk.values.KV
+import org.apache.beam.sdk.values.PCollection
+import org.apache.beam.sdk.values.PCollectionList
+import org.apache.beam.sdk.values.PCollectionView
+import org.apache.beam.sdk.values.TupleTag
+
+infix fun <KeyT, ValueT> KeyT.toKv(value: ValueT): KV<KeyT, ValueT> {
+  return KV.of(this, value)
+}
+
+fun <KeyT, ValueT> PCollection<KV<KeyT, ValueT>>.keys(): PCollection<KeyT> {
+  return apply(Keys.create())
+}
+
+inline fun <InT, reified OutT> PCollection<InT>.parDo(
+  crossinline block: suspend SequenceScope<OutT>.(InT) -> Unit
+): PCollection<OutT> {
+  return apply(
+    ParDo.of(
+      object : DoFn<InT, OutT>() {
+        @ProcessElement
+        fun processElement(@Element element: InT, output: OutputReceiver<OutT>) {
+          sequence<OutT> { block(element) }.forEach(output::output)
+        }
+      }
+    )
+  )
+}
+
+inline fun <InT, reified OutT> PCollection<InT>.map(
+  crossinline block: (InT) -> OutT
+): PCollection<OutT> {
+  return parDo { yield(block(it)) }
+}
+
+inline fun <InputT, reified KeyT> PCollection<InputT>.keyBy(
+  crossinline keySelector: (InputT) -> KeyT
+): PCollection<KV<KeyT, InputT>> {
+  return map { keySelector(it) toKv it }
+}
+
+inline fun <InKeyT, reified OutKeyT, reified ValueT> PCollection<KV<InKeyT, ValueT>>.mapKeys(
+  crossinline block: (InKeyT) -> OutKeyT
+): PCollection<KV<OutKeyT, ValueT>> {
+  return map { block(it.key) toKv it.value }
+}
+
+fun <T> PCollection<T>.partition(numParts: Int, block: (T) -> Int): PCollectionList<T> {
+  return Partition.of(numParts) { value: T, _ -> block(value) }.expand(this)
+}
+
+inline fun <reified KeyT, reified Value1T, reified Value2T, reified OutT> PCollection<
+  KV<KeyT, Value1T>>.join(
+  right: PCollection<KV<KeyT, Value2T>>,
+  crossinline transform:
+    suspend SequenceScope<OutT>.(KeyT, Iterable<Value1T>, Iterable<Value2T>) -> Unit
+): PCollection<OutT> {
+  val leftTag = object : TupleTag<Value1T>() {}
+  val rightTag = object : TupleTag<Value2T>() {}
+  return KeyedPCollectionTuple.of(leftTag, this)
+    .and(rightTag, right)
+    .apply(CoGroupByKey.create())
+    .parDo { transform(it.key, it.value.getAll(leftTag), it.value.getAll(rightTag)) }
+}
+
+fun <T> PCollection<T>.count(): PCollectionView<Long> {
+  return Combine.globally<T, Long>(Count.combineFn()).asSingletonView().expand(this)
+}
+
+fun <T> Iterable<PCollection<T>>.toPCollectionList(): PCollectionList<T> {
+  return PCollectionList.of(this)
+}
+
+fun <T> PCollectionList<T>.flatten(): PCollection<T> {
+  return apply(Flatten.pCollections())
+}
+
+inline fun <InT, reified SideT, reified OutT> PCollection<InT>.parDoWithSideInput(
+  sideInput: PCollectionView<SideT>,
+  crossinline block: suspend SequenceScope<OutT>.(InT, SideT) -> Unit
+): PCollection<OutT> {
+  val doFn =
+    object : DoFn<InT, OutT>() {
+      @ProcessElement
+      fun processElement(
+        @Element element: InT,
+        out: OutputReceiver<OutT>,
+        context: ProcessContext
+      ) {
+        sequence<OutT> { block(element, context.sideInput(sideInput)) }.forEach(out::output)
+      }
+    }
+  return ParDo.of(doFn).withSideInputs(sideInput).expand(this)
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/common/beam/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/beam/testing/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+package(default_visibility = [
+    "//src/test/kotlin/org/wfanet/panelmatch:__subpackages__",
+])
+
+kt_jvm_library(
+    name = "testing",
+    srcs = glob(["*.kt"]),
+    deps = [
+        "//imports/java/com/google/common:guava",
+        "//imports/java/org/apache/beam:core",
+        "//imports/java/org/apache/beam:direct_runner",
+        "//imports/java/org/hamcrest:core",
+        "//imports/java/org/hamcrest:library",
+        "//src/main/kotlin/org/wfanet/panelmatch/common/beam",
+        "@wfa_measurement_system//imports/java/org/junit",
+    ],
+)

--- a/src/main/kotlin/org/wfanet/panelmatch/common/beam/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/beam/testing/BUILD.bazel
@@ -13,6 +13,7 @@ kt_jvm_library(
         "//imports/java/org/apache/beam:direct_runner",
         "//imports/java/org/hamcrest:core",
         "//imports/java/org/hamcrest:library",
+        "//imports/java/org/slf4j:simple",
         "//src/main/kotlin/org/wfanet/panelmatch/common/beam",
         "@wfa_measurement_system//imports/java/org/junit",
     ],

--- a/src/main/kotlin/org/wfanet/panelmatch/common/beam/testing/BeamTestBase.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/beam/testing/BeamTestBase.kt
@@ -1,0 +1,62 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.common.beam.testing
+
+import org.apache.beam.sdk.testing.PAssert
+import org.apache.beam.sdk.testing.TestPipeline
+import org.apache.beam.sdk.transforms.Create
+import org.apache.beam.sdk.transforms.DoFn
+import org.apache.beam.sdk.transforms.ParDo
+import org.apache.beam.sdk.values.PCollection
+import org.apache.beam.sdk.values.PCollectionView
+import org.junit.Rule
+
+/**
+ * Base class for Apache Beam tests.
+ *
+ * This makes a [TestPipeline] available to subclasses and sets it to run automatically in each test
+ * case. It also provides a convenience function for building [PCollection]s.
+ */
+open class BeamTestBase {
+  @get:Rule
+  val pipeline: TestPipeline =
+    TestPipeline.create().enableAbandonedNodeEnforcement(false).enableAutoRunIfMissing(true)
+
+  protected fun <T> pcollectionOf(name: String, vararg values: T): PCollection<T> {
+    return pipeline.apply(name, Create.of(values.asIterable()))
+  }
+}
+
+fun <T> assertThat(pCollection: PCollection<T>): PAssert.IterableAssert<T> {
+  return PAssert.that(pCollection)
+}
+
+inline fun <reified T> assertThat(view: PCollectionView<T>): PAssert.IterableAssert<T> {
+  val parDo =
+    object : DoFn<Int, T>() {
+      @ProcessElement
+      fun processElement(context: ProcessContext, out: OutputReceiver<T>) {
+        out.output(context.sideInput(view))
+      }
+    }
+
+  val extractedResult =
+    view
+      .pipeline
+      .apply("Create Dummy PCollection", Create.of(1))
+      .apply(ParDo.of(parDo).withSideInputs(view))
+
+  return assertThat(extractedResult)
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/common/beam/testing/BeamTestBase.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/beam/testing/BeamTestBase.kt
@@ -19,6 +19,7 @@ import org.apache.beam.sdk.testing.TestPipeline
 import org.apache.beam.sdk.transforms.Create
 import org.apache.beam.sdk.transforms.DoFn
 import org.apache.beam.sdk.transforms.ParDo
+import org.apache.beam.sdk.transforms.View
 import org.apache.beam.sdk.values.PCollection
 import org.apache.beam.sdk.values.PCollectionView
 import org.junit.Rule
@@ -36,6 +37,10 @@ open class BeamTestBase {
 
   protected fun <T> pcollectionOf(name: String, vararg values: T): PCollection<T> {
     return pipeline.apply(name, Create.of(values.asIterable()))
+  }
+
+  protected fun <T> pcollectionViewOf(name: String, value: T): PCollectionView<T> {
+    return pcollectionOf("$name:Create", value).apply("$name:View", View.asSingleton())
   }
 }
 

--- a/src/test/kotlin/org/wfanet/panelmatch/common/beam/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/common/beam/BUILD.bazel
@@ -1,0 +1,20 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "BeamTest",
+    srcs = ["BeamTest.kt"],
+    test_class = "org.wfanet.panelmatch.common.beam.BeamTest",
+    deps = [
+        "//imports/java/com/google/common:guava",
+        "//imports/java/org/apache/beam:core",
+        "//imports/java/org/apache/beam:direct_runner",
+        "//imports/java/org/hamcrest:core",
+        "//imports/java/org/hamcrest:library",
+        "//src/main/kotlin/org/wfanet/panelmatch/common/beam",
+        "@wfa_measurement_system//imports/java/com/google/common/truth",
+        "@wfa_measurement_system//imports/java/com/google/common/truth/extensions/proto",
+        "@wfa_measurement_system//imports/java/org/junit",
+        "@wfa_measurement_system//imports/kotlin/com/nhaarman/mockitokotlin2",
+        "@wfa_measurement_system//imports/kotlin/kotlin/test",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/panelmatch/common/beam/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/common/beam/BUILD.bazel
@@ -7,14 +7,9 @@ kt_jvm_test(
     deps = [
         "//imports/java/com/google/common:guava",
         "//imports/java/org/apache/beam:core",
-        "//imports/java/org/apache/beam:direct_runner",
-        "//imports/java/org/hamcrest:core",
-        "//imports/java/org/hamcrest:library",
         "//src/main/kotlin/org/wfanet/panelmatch/common/beam",
+        "//src/main/kotlin/org/wfanet/panelmatch/common/beam/testing",
         "@wfa_measurement_system//imports/java/com/google/common/truth",
-        "@wfa_measurement_system//imports/java/com/google/common/truth/extensions/proto",
         "@wfa_measurement_system//imports/java/org/junit",
-        "@wfa_measurement_system//imports/kotlin/com/nhaarman/mockitokotlin2",
-        "@wfa_measurement_system//imports/kotlin/kotlin/test",
     ],
 )

--- a/src/test/kotlin/org/wfanet/panelmatch/common/beam/BeamTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/common/beam/BeamTest.kt
@@ -1,0 +1,157 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.common.beam
+
+import com.google.common.truth.Truth.assertThat
+import org.apache.beam.sdk.testing.PAssert
+import org.apache.beam.sdk.testing.TestPipeline
+import org.apache.beam.sdk.transforms.Create
+import org.apache.beam.sdk.transforms.DoFn
+import org.apache.beam.sdk.transforms.ParDo
+import org.apache.beam.sdk.values.KV
+import org.apache.beam.sdk.values.PCollection
+import org.apache.beam.sdk.values.PCollectionList
+import org.apache.beam.sdk.values.PCollectionView
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class BeamTest {
+  @get:Rule
+  val pipeline: TestPipeline =
+    TestPipeline.create().enableAbandonedNodeEnforcement(false).enableAutoRunIfMissing(true)
+
+  private val collection: PCollection<KV<Int, String>> by lazy {
+    pcollectionOf("collection", 1 toKv "A", 2 toKv "B", 3 toKv "C")
+  }
+
+  private fun <T> pcollectionOf(name: String, vararg values: T): PCollection<T> {
+    return pipeline.apply(name, Create.of(values.asIterable()))
+  }
+
+  private fun <T> assertThat(pCollection: PCollection<T>): PAssert.IterableAssert<T> {
+    return PAssert.that(pCollection)
+  }
+
+  @Test
+  fun keys() {
+    assertThat(collection.keys()).containsInAnyOrder(1, 2, 3)
+  }
+
+  @Test
+  fun parDo() {
+    val result: PCollection<Int> =
+      collection.parDo {
+        yield(it.key + 10)
+        yield(it.key + 100)
+      }
+
+    assertThat(result).containsInAnyOrder(11, 101, 12, 102, 13, 103)
+  }
+
+  @Test
+  fun map() {
+    assertThat(collection.map { it.key + 10 }).containsInAnyOrder(11, 12, 13)
+  }
+
+  @Test
+  fun keyBy() {
+    assertThat(pcollectionOf("unkeyed-items", 1, 2, 3).keyBy { it + 10 })
+      .containsInAnyOrder(11 toKv 1, 12 toKv 2, 13 toKv 3)
+  }
+
+  @Test
+  fun mapKeys() {
+    assertThat(collection.mapKeys { -it }).containsInAnyOrder(-1 toKv "A", -2 toKv "B", -3 toKv "C")
+  }
+
+  @Test
+  fun partition() {
+    val parts: PCollectionList<KV<Int, String>> = collection.partition(2) { it.key % 2 }
+    assertThat(parts.size()).isEqualTo(2)
+    assertThat(parts[0]).containsInAnyOrder(2 toKv "B")
+    assertThat(parts[1]).containsInAnyOrder(1 toKv "A", 3 toKv "C")
+  }
+
+  @Test
+  fun join() {
+    val rightHandSide = pcollectionOf("right-hand side", 1 toKv 'a', 1 toKv 'b', 4 toKv 'c')
+    val result: PCollection<KV<Int, String>> =
+      collection.join(rightHandSide) { key, lefts, rights ->
+        val leftString = lefts.sorted().joinToString(", ")
+        val rightString = rights.sorted().joinToString(", ")
+        yield(key toKv "[$leftString] and [$rightString]")
+      }
+    assertThat(result)
+      .containsInAnyOrder(
+        1 toKv "[A] and [a, b]",
+        2 toKv "[B] and []",
+        3 toKv "[C] and []",
+        4 toKv "[] and [c]"
+      )
+  }
+
+  @Test
+  fun joinIgnoringArguments() {
+    val rightHandSide = pcollectionOf("right-hand side", 1 toKv 'a', 1 toKv 'b', 4 toKv 'c')
+    val result: PCollection<Int> = collection.join(rightHandSide) { _, _, _ -> yield(1) }
+    assertThat(result).containsInAnyOrder(1, 1, 1, 1)
+  }
+
+  @Test
+  fun count() {
+    @Suppress("UNCHECKED_CAST") val result: PCollectionView<Long> = collection.count()
+    val extractedResult =
+      pcollectionOf("dummy", 1)
+        .apply(
+          ParDo.of(
+              object : DoFn<Int, Long>() {
+                @ProcessElement
+                fun processElement(context: ProcessContext, out: OutputReceiver<Long>) {
+                  out.output(context.sideInput(result))
+                }
+              }
+            )
+            .withSideInputs(result)
+        )
+    assertThat(extractedResult).containsInAnyOrder(3L)
+  }
+
+  @Test
+  fun toPCollectionList() {
+    val list =
+      listOf(pcollectionOf("first", 1, 2, 3), pcollectionOf("second", 4, 5, 6)).toPCollectionList()
+    assertThat(list.size()).isEqualTo(2)
+    assertThat(list[0]).containsInAnyOrder(1, 2, 3)
+    assertThat(list[1]).containsInAnyOrder(4, 5, 6)
+  }
+
+  @Test
+  fun flatten() {
+    val list =
+      listOf(pcollectionOf("first", 1, 2, 3), pcollectionOf("second", 4, 5, 6)).toPCollectionList()
+    assertThat(list.flatten()).containsInAnyOrder(1, 2, 3, 4, 5, 6)
+  }
+
+  @Test
+  fun parDoWithSideInput() {
+    val sideInput = collection.count()
+    val result: PCollection<KV<Int, Long>> =
+      collection.parDoWithSideInput(sideInput) { element, count -> yield(element.key toKv count) }
+    assertThat(result).containsInAnyOrder(1 toKv 3L, 2 toKv 3L, 3 toKv 3L)
+  }
+}

--- a/src/test/kotlin/org/wfanet/panelmatch/common/beam/BeamTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/common/beam/BeamTest.kt
@@ -128,4 +128,14 @@ class BeamTest : BeamTestBase() {
       collection.parDoWithSideInput(sideInput) { element, count -> yield(element.key toKv count) }
     assertThat(result).containsInAnyOrder(1 toKv 3L, 2 toKv 3L, 3 toKv 3L)
   }
+
+  @Test
+  fun combinePerKey() {
+    val result =
+      pcollectionOf("values", "A" toKv 1, "A" toKv 2, "B" toKv 5).combinePerKey {
+        it.reduce(Int::plus)
+      }
+
+    assertThat(result).containsInAnyOrder("A" toKv 3, "B" toKv 5)
+  }
 }


### PR DESCRIPTION
This allows using Apache Beam in common ways in a more Kotlin-centric
way, rather than the very Java-centric Beam Java SDK.

Apache Beam will be used for several things, including a pipeline for
preparing/encrypting event level data.