### PR TITLE
Add HKDF Wrapper class for user data encryption

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,6 @@ http_archive(
     ],
 )
 
-
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
@@ -198,7 +197,6 @@ load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 container_deps()
 
 load("//build/io_bazel_rules_docker:base_images.bzl", "base_java_images")
-
 
 # Defualt base images for java_image targets. Must come before
 # java_image_repositories().

--- a/src/main/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
@@ -59,12 +59,17 @@ cc_library(
 
 cc_library(
     name = "hkdf",
+    srcs = [
+        "hkdf.cc",
+    ],
     hdrs = [
         "hkdf.h",
     ],
     strip_include_prefix = _INCLUDE_PREFIX,
     deps = [
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@tink_base//cc/util:secret_data",
+        "@tink_cc//subtle",
     ],
 )

--- a/src/main/cc/wfanet/panelmatch/common/crypto/hkdf.cc
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/hkdf.cc
@@ -19,6 +19,7 @@
 #include "tink/subtle/hkdf.h"
 
 namespace wfanet::panelmatch::common::crypto {
+namespace {
 
 using ::crypto::tink::util::SecretData;
 
@@ -42,8 +43,10 @@ class Sha256Hkdf : public Hkdf {
         ::crypto::tink::subtle::SHA256, ikm, "", "", length);
   }
 };
+}  // namespace
 
-const Hkdf& GetHkdf() {
+// Returns an instance of the Sha256Hkdf class
+const Hkdf& GetSha256Hkdf() {
   static const auto* const hkdf = new Sha256Hkdf();
   return *hkdf;
 }

--- a/src/main/cc/wfanet/panelmatch/common/crypto/hkdf.cc
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/hkdf.cc
@@ -1,0 +1,51 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "wfanet/panelmatch/common/crypto/hkdf.h"
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "tink/subtle/hkdf.h"
+
+namespace wfanet::panelmatch::common::crypto {
+
+using ::crypto::tink::util::SecretData;
+
+// Implements HMAC-based Extract-and-Expand Key Derivation Function (HKDF)
+// from RFC5869 (https://tools.ietf.org/html/rfc5869)
+class Sha256Hkdf : public Hkdf {
+ public:
+  Sha256Hkdf() = default;
+
+  // Generates an encryption key from a SecretData input
+  absl::StatusOr<SecretData> ComputeHkdf(const SecretData& ikm,
+                                         int length) const override {
+    if (length < 1 || length > 1024) {
+      return absl::InvalidArgumentError(
+          "Invalid length: Must be between 1 and 1024");
+    } else if (ikm.empty()) {
+      return absl::InvalidArgumentError("Invalid ikm: Must not be empty");
+    }
+
+    return ::crypto::tink::subtle::Hkdf::ComputeHkdf(
+        ::crypto::tink::subtle::SHA256, ikm, "", "", length);
+  }
+};
+
+const Hkdf& GetHkdf() {
+  static const auto* const hkdf = new Sha256Hkdf();
+  return *hkdf;
+}
+
+}  // namespace wfanet::panelmatch::common::crypto

--- a/src/main/cc/wfanet/panelmatch/common/crypto/hkdf.cc
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/hkdf.cc
@@ -45,7 +45,6 @@ class Sha256Hkdf : public Hkdf {
 };
 }  // namespace
 
-// Returns an instance of the Sha256Hkdf class
 const Hkdf& GetSha256Hkdf() {
   static const auto* const hkdf = new Sha256Hkdf();
   return *hkdf;

--- a/src/main/cc/wfanet/panelmatch/common/crypto/hkdf.h
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/hkdf.h
@@ -31,7 +31,8 @@ class Hkdf {
       const ::crypto::tink::util::SecretData& ikm, int length) const = 0;
 };
 
-const Hkdf& GetHkdf();
+// Returns an instance of the Sha256Hkdf class
+const Hkdf& GetSha256Hkdf();
 
 }  // namespace wfanet::panelmatch::common::crypto
 

--- a/src/main/cc/wfanet/panelmatch/common/crypto/hkdf.h
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/hkdf.h
@@ -31,7 +31,7 @@ class Hkdf {
       const ::crypto::tink::util::SecretData& ikm, int length) const = 0;
 };
 
-// Returns an instance of the Sha256Hkdf class
+// Returns an Hkdf that uses SHA-256 as the hash function
 const Hkdf& GetSha256Hkdf();
 
 }  // namespace wfanet::panelmatch::common::crypto

--- a/src/main/cc/wfanet/panelmatch/common/crypto/hkdf.h
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/hkdf.h
@@ -17,20 +17,21 @@
 #ifndef SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_CRYPTO_HKDF_H_
 #define SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_CRYPTO_HKDF_H_
 
-namespace wfanet::panelmatch::common::crypto {
-
 #include "absl/status/statusor.h"
 #include "tink/util/secret_data.h"
 
+namespace wfanet::panelmatch::common::crypto {
 // Implements HMAC-based Extract-and-Expand Key Derivation Function (HKDF)
 // from RFC5869 (https://tools.ietf.org/html/rfc5869)
 class Hkdf {
  public:
   virtual ~Hkdf() = default;
   // Generates an encryption key from a SecretData input
-  virtual absl::StatusOr<crypto::tink::util::SecretData> ComputeHkdf(
-      const crypto::tink::util::SecretData& ikm) = 0;
+  virtual absl::StatusOr<::crypto::tink::util::SecretData> ComputeHkdf(
+      const ::crypto::tink::util::SecretData& ikm, int length) const = 0;
 };
+
+const Hkdf& GetHkdf();
 
 }  // namespace wfanet::panelmatch::common::crypto
 

--- a/src/test/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
+++ b/src/test/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
@@ -11,3 +11,20 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "hkdf_test",
+    srcs = [
+        "hkdf_test.cc",
+    ],
+    deps = [
+        "//src/main/cc/wfanet/panelmatch/common/crypto:hkdf",
+        "//src/test/cc/testutil:matchers",
+        "//src/test/cc/testutil:status_macros",
+        "@googletest//:gtest_main",
+        "@tink_base//cc/util:secret_data",
+        "@tink_base//cc/util:status",
+        "@tink_base//cc/util:statusor",
+        "@tink_cc//util:test_util",
+    ],
+)

--- a/src/test/cc/wfanet/panelmatch/common/crypto/hkdf_test.cc
+++ b/src/test/cc/wfanet/panelmatch/common/crypto/hkdf_test.cc
@@ -1,0 +1,77 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "wfanet/panelmatch/common/crypto/hkdf.h"
+
+#include "gtest/gtest.h"
+#include "src/test/cc/testutil/matchers.h"
+#include "src/test/cc/testutil/status_macros.h"
+#include "tink/util/secret_data.h"
+#include "tink/util/status.h"
+#include "tink/util/statusor.h"
+#include "tink/util/test_util.h"
+
+namespace wfanet::panelmatch::common::crypto {
+namespace {
+using ::crypto::tink::test::HexDecodeOrDie;
+using ::crypto::tink::test::HexEncode;
+using ::crypto::tink::util::SecretData;
+using ::crypto::tink::util::SecretDataAsStringView;
+using ::crypto::tink::util::SecretDataFromStringView;
+
+// Test with a proper SecretData value and length value
+TEST(HkdfTest, properCall) {
+  const Hkdf& hkdf = GetHkdf();
+  ASSERT_OK_AND_ASSIGN(
+      SecretData result,
+      hkdf.ComputeHkdf(SecretDataFromStringView(HexDecodeOrDie(
+                           "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b")),
+                       42));
+  EXPECT_EQ(HexEncode(SecretDataAsStringView(result)),
+            "8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d"
+            "201395faa4b61a96c8");
+}
+
+// Test with an empty key and proper length
+TEST(HkdfTest, emptyKey) {
+  const Hkdf& hkdf = GetHkdf();
+  auto result = hkdf.ComputeHkdf(SecretDataFromStringView(""), 42);
+  EXPECT_THAT(result.status(),
+              StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
+// Test with a proper key and length < 1
+TEST(HkdfTest, lengthTooSmall) {
+  const Hkdf& hkdf = GetHkdf();
+  auto result = hkdf.ComputeHkdf(
+      SecretDataFromStringView(
+          HexDecodeOrDie("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b")),
+      -6);
+  EXPECT_THAT(result.status(),
+              StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
+// Test with null key and length > 1024
+TEST(HkdfTest, lengthTooBig) {
+  const Hkdf& hkdf = GetHkdf();
+  auto result = hkdf.ComputeHkdf(
+      SecretDataFromStringView(
+          HexDecodeOrDie("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b")),
+      10000);
+  EXPECT_THAT(result.status(),
+              StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+}  // namespace
+
+}  // namespace wfanet::panelmatch::common::crypto


### PR DESCRIPTION
Add implementation and test cases for HKDF for generating an AES key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/34)
<!-- Reviewable:end -->
