### PR TITLE
Add pseudo-implementation for AES

### DIFF
--- a/src/main/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
@@ -6,14 +6,19 @@ _INCLUDE_PREFIX = "/src/main/cc"
 
 cc_library(
     name = "aes",
+    srcs = [
+        "aes.cc",
+    ],
     hdrs = [
         "aes.h",
     ],
     strip_include_prefix = _INCLUDE_PREFIX,
     deps = [
         "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@tink_base//cc/util:secret_data",
+        # "@tink_cc//subtle:aes_siv_boringssl",
     ],
 )
 

--- a/src/main/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
@@ -14,11 +14,10 @@ cc_library(
     ],
     strip_include_prefix = _INCLUDE_PREFIX,
     deps = [
-        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@tink_base//cc/util:secret_data",
-        # "@tink_cc//subtle:aes_siv_boringssl",
     ],
 )
 

--- a/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
@@ -19,7 +19,6 @@
 namespace wfanet::panelmatch::common::crypto {
 namespace {
 
-using absl::string_view;
 using ::crypto::tink::util::SecretData;
 
 class AesSiv : public Aes {

--- a/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "wfanet/panelmatch/common/crypto/aes.h"
-// #include "tink/cc/subtle/aes_siv_boringssl.h"
+
 #include "absl/status/status.h"
 
 namespace wfanet::panelmatch::common::crypto {
@@ -21,29 +21,25 @@ namespace {
 
 using ::crypto::tink::util::SecretData;
 
+// Implements an Aes SIV encryption scheme defined in
+// https://datatracker.ietf.org/doc/html/rfc5297
 class AesSiv : public Aes {
  public:
   AesSiv() = default;
 
   absl::StatusOr<std::string> Encrypt(absl::string_view input,
                                       const SecretData& key) const override {
-    //    AesSivBoringSsl implementation = new AesSivBoringSsl(key);
-    //    return implementation.EncryptDeterministically(input, "");
-
     return absl::UnimplementedError("Not implemented");
   }
 
   absl::StatusOr<std::string> Decrypt(absl::string_view input,
                                       const SecretData& key) const override {
-    //    AesSivBoringSsl implementation = new AesSivBoringSsl(key);
-    //    return implementation.DecryptDeterministically(input, "");
-
     return absl::UnimplementedError("Not implemented");
   }
 };
 }  // namespace
 
-const Aes& GetAesSiv() {
+const Aes& GetAesSivCmac512() {
   static const auto* const aes = new AesSiv();
   return *aes;
 }

--- a/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
@@ -25,7 +25,7 @@ class AesSiv : public Aes {
  public:
   AesSiv() = default;
 
-  absl::StatusOr<std::string> Encrypt(string_view input,
+  absl::StatusOr<std::string> Encrypt(absl::string_view input,
                                       const SecretData& key) const override {
     //    AesSivBoringSsl implementation = new AesSivBoringSsl(key);
     //    return implementation.EncryptDeterministically(input, "");
@@ -33,7 +33,7 @@ class AesSiv : public Aes {
     return absl::UnimplementedError("Not implemented");
   }
 
-  absl::StatusOr<std::string> Decrypt(string_view input,
+  absl::StatusOr<std::string> Decrypt(absl::string_view input,
                                       const SecretData& key) const override {
     //    AesSivBoringSsl implementation = new AesSivBoringSsl(key);
     //    return implementation.DecryptDeterministically(input, "");

--- a/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "wfanet/panelmatch/common/crypto/aes.h"
-//#include "tink/cc/subtle/aes_siv_boringssl.h"
+// #include "tink/cc/subtle/aes_siv_boringssl.h"
 #include "absl/status/status.h"
 
 namespace wfanet::panelmatch::common::crypto {

--- a/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
@@ -1,0 +1,37 @@
+#include "wfanet/panelmatch/common/crypto/aes.h"
+//#include "tink/cc/subtle/aes_siv_boringssl.h"
+#include "absl/status/status.h"
+
+namespace wfanet::panelmatch::common::crypto {
+namespace {
+
+using absl::string_view;
+using ::crypto::tink::util::SecretData;
+
+class AesSiv : public Aes {
+ public:
+  AesSiv() = default;
+
+  absl::StatusOr<std::string> Encrypt(string_view input,
+                                      const SecretData& key) const override {
+    //    AesSivBoringSsl implementation = new AesSivBoringSsl(key);
+    //    return implementation.EncryptDeterministically(input, "");
+
+    return absl::UnimplementedError("Not implemented");
+  }
+
+  absl::StatusOr<std::string> Decrypt(string_view input,
+                                      const SecretData& key) const override {
+    //    AesSivBoringSsl implementation = new AesSivBoringSsl(key);
+    //    return implementation.DecryptDeterministically(input, "");
+
+    return absl::UnimplementedError("Not implemented");
+  }
+};
+}  // namespace
+
+const Aes& GetAesSiv() {
+  static const auto* const aes = new AesSiv();
+  return *aes;
+}
+}  // namespace wfanet::panelmatch::common::crypto

--- a/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
@@ -1,3 +1,17 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "wfanet/panelmatch/common/crypto/aes.h"
 //#include "tink/cc/subtle/aes_siv_boringssl.h"
 #include "absl/status/status.h"

--- a/src/main/cc/wfanet/panelmatch/common/crypto/aes.h
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/aes.h
@@ -43,7 +43,10 @@ class Aes {
       const ::crypto::tink::util::SecretData& key) const = 0;
 };
 
-const Aes& GetAesSiv();
+// Return Aes encryption scheme with a key size of 64 bytes and implements
+// AEAD_AES_SIV_CMAC_512 as defined by
+// https://datatracker.ietf.org/doc/html/rfc5297#section-6.3.
+const Aes& GetAesSivCmac512();
 
 }  // namespace wfanet::panelmatch::common::crypto
 

--- a/src/main/cc/wfanet/panelmatch/common/crypto/aes.h
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/aes.h
@@ -17,13 +17,13 @@
 #ifndef SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_CRYPTO_AES_H_
 #define SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_CRYPTO_AES_H_
 
-namespace wfanet::panelmatch::common::crypto {
-
 #include <string>
 
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "tink/util/secret_data.h"
+
+namespace wfanet::panelmatch::common::crypto {
 
 // Implements an AES encryption scheme
 class Aes {
@@ -33,13 +33,17 @@ class Aes {
   // This will return an error status if the key is the wrong size for the
   // given AES implementation
   virtual absl::StatusOr<std::string> Encrypt(
-      absl::string_view input, const crypto::tink::util::SecretData key) = 0;
+      absl::string_view input,
+      const ::crypto::tink::util::SecretData& key) const = 0;
   // Decrypts `input` using AES key `key`
   // This will return an error status if the key is the wrong size for the
   // given AES implementation
   virtual absl::StatusOr<std::string> Decrypt(
-      absl::string_view input, const crypto::tink::util::SecretData key) = 0;
+      absl::string_view input,
+      const ::crypto::tink::util::SecretData& key) const = 0;
 };
+
+const Aes& GetAesSiv();
 
 }  // namespace wfanet::panelmatch::common::crypto
 

--- a/src/main/cc/wfanet/panelmatch/protocol/crypto/event_data_preprocessor.h
+++ b/src/main/cc/wfanet/panelmatch/protocol/crypto/event_data_preprocessor.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_MAIN_CC_WFANET_PANELMATCH_PROTOCOL_CRYPTO_EVENT_DATA_PREPROCESSOR_H_
+#define SRC_MAIN_CC_WFANET_PANELMATCH_PROTOCOL_CRYPTO_EVENT_DATA_PREPROCESSOR_H_
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+
+namespace wfanet::panelmatch::protocol::crypto {
+
+struct ProcessedData {
+  absl::string_view encrypted_identifier;
+  absl::string_view encrypted_events;
+};
+
+// Implements AES, HKDF, and Sha256 to encrypt event data
+class EventDataPreprocessor {
+ public:
+  virtual ~EventDataPreprocessor() = default;
+  // Encrypts 'identifier' and 'event' data
+  virtual absl::StatusOr<ProcessedData> Process(absl::string_view identifier,
+                                                absl::string_view event) = 0;
+};
+
+}  // namespace wfanet::panelmatch::protocol::crypto
+
+#endif  // SRC_MAIN_CC_WFANET_PANELMATCH_PROTOCOL_CRYPTO_EVENT_DATA_PREPROCESSOR_H_

--- a/src/main/cc/wfanet/panelmatch/protocol/crypto/event_data_preprocessor.h
+++ b/src/main/cc/wfanet/panelmatch/protocol/crypto/event_data_preprocessor.h
@@ -24,16 +24,20 @@ namespace wfanet::panelmatch::protocol::crypto {
 
 struct ProcessedData {
   absl::string_view encrypted_identifier;
-  absl::string_view encrypted_events;
+  absl::string_view encrypted_event_data;
 };
 
-// Implements AES, HKDF, and Sha256 to encrypt event data
+// Implements several encryption schemes to encrypt event data and an
+// identifier. A deterministic commutative encryption scheme is used to encrypt
+// the identifier, which is hashed using a Sha256 method.  The encrypted
+// identifier is also used in an HKDF method to create an AES key, which is used
+// for an AES encryption/decryption of event data.
 class EventDataPreprocessor {
  public:
   virtual ~EventDataPreprocessor() = default;
   // Encrypts 'identifier' and 'event' data
-  virtual absl::StatusOr<ProcessedData> Process(absl::string_view identifier,
-                                                absl::string_view event) = 0;
+  virtual absl::StatusOr<ProcessedData> Process(
+      absl::string_view identifier, absl::string_view event_data) = 0;
 };
 
 }  // namespace wfanet::panelmatch::protocol::crypto

--- a/src/test/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
+++ b/src/test/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
@@ -13,6 +13,17 @@ cc_test(
 )
 
 cc_test(
+    name = "aes_test",
+    srcs = ["aes_test.cc"],
+    deps = [
+        "//src/main/cc/wfanet/panelmatch/common/crypto:aes",
+        "//src/test/cc/testutil:matchers",
+        "@com_google_absl//absl/strings",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "hkdf_test",
     srcs = [
         "hkdf_test.cc",

--- a/src/test/cc/wfanet/panelmatch/common/crypto/aes_test.cc
+++ b/src/test/cc/wfanet/panelmatch/common/crypto/aes_test.cc
@@ -18,7 +18,6 @@
 
 #include "gtest/gtest.h"
 #include "src/test/cc/testutil/matchers.h"
-// #include "tink/util/secret_data.h"
 
 namespace wfanet::panelmatch::common::crypto {
 namespace {
@@ -26,46 +25,25 @@ namespace {
 using ::crypto::tink::util::SecretDataFromStringView;
 
 TEST(AesTest, unimplementedEncrypt) {
-  const Aes& aes = GetAesSiv();
+  const Aes& aes = GetAesSivCmac512();
   auto result = aes.Encrypt("input", SecretDataFromStringView("key"));
   EXPECT_THAT(result.status(), StatusIs(absl::StatusCode::kUnimplemented, ""));
 }
 
 TEST(AesTest, unimplementedDecrypt) {
-  const Aes& aes = GetAesSiv();
+  const Aes& aes = GetAesSivCmac512();
   auto result = aes.Decrypt("input", SecretDataFromStringView("key"));
   EXPECT_THAT(result.status(), StatusIs(absl::StatusCode::kUnimplemented, ""));
 }
 
-// A round trip test to ensure the value encrypted then decrypted results in the
-// original value
-// TEST(AesTest, EncryptDecrypt) {
-// util::SecretData key = util::SecretDataFromStringView(test::HexDecodeOrDie(
-//     "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
-//     "00112233445566778899aabbccddeefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"));
-// auto res = AesSivBoringSsl::New(key);
-// EXPECT_TRUE(res.ok()) << res.status();
-// auto cipher = std::move(res.ValueOrDie());
-// std::string aad = "Additional data";
-// std::string message = "Some data to encrypt.";
-// auto ct = cipher->Encrypt(message, aad);
-// EXPECT_TRUE(ct.ok()) << ct.status();
-// auto pt = cipher->Decrypt(ct.ValueOrDie(), aad);
-// EXPECT_TRUE(pt.ok()) << pt.status();
-// EXPECT_EQ(pt.ValueOrDie(), message);
-// }
-
-// Compares the output of AesSiv to AesSivBoringSsl
-
-// Wrong key size
-
-// Null input
-
-// Null key
-
-// Different key with same string are different things
-
-// Same key with different strings are different things
+// TODO(efreck): Implement the following test cases
+//  - Encrypt/Decrypt
+//  - Compares the output of AesSiv to AesSivBoringSsl
+//  - Wrong key size
+//  - Null input
+//  - Null key
+//  - Different key with same string are different things
+//  - Same key with different strings are different things
 
 }  // namespace
 }  // namespace wfanet::panelmatch::common::crypto

--- a/src/test/cc/wfanet/panelmatch/common/crypto/aes_test.cc
+++ b/src/test/cc/wfanet/panelmatch/common/crypto/aes_test.cc
@@ -18,7 +18,7 @@
 
 #include "gtest/gtest.h"
 #include "src/test/cc/testutil/matchers.h"
-//#include "tink/util/secret_data.h"
+// #include "tink/util/secret_data.h"
 
 namespace wfanet::panelmatch::common::crypto {
 namespace {

--- a/src/test/cc/wfanet/panelmatch/common/crypto/aes_test.cc
+++ b/src/test/cc/wfanet/panelmatch/common/crypto/aes_test.cc
@@ -1,0 +1,61 @@
+#include "wfanet/panelmatch/common/crypto/aes.h"
+
+#include <string>
+
+#include "gtest/gtest.h"
+#include "src/test/cc/testutil/matchers.h"
+//#include "tink/util/secret_data.h"
+
+namespace crypto {
+namespace tink {
+namespace subtle {
+namespace {
+
+using ::crypto::tink::util::SecretDataFromStringView;
+
+TEST(AesTest, unimplementedEncrypt) {
+  const Aes& aes = GetAesSiv();
+  auto result = aes.Encrypt("input", SecretDataFromStringView("key"));
+  EXPECT_THAT(result.status(), StatusIs(absl::StatusCode::kUnimplemented, ""));
+}
+
+TEST(AesTest, unimplementedDecrypt) {
+  const Aes& aes = GetAesSiv();
+  auto result = aes.Decrypt("input", SecretDataFromStringView("key"));
+  EXPECT_THAT(result.status(), StatusIs(absl::StatusCode::kUnimplemented, ""));
+}
+
+// A round trip test to ensure the value encrypted then decrypted results in the
+// original value
+// TEST(AesTest, EncryptDecrypt) {
+// util::SecretData key = util::SecretDataFromStringView(test::HexDecodeOrDie(
+//     "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+//     "00112233445566778899aabbccddeefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"));
+// auto res = AesSivBoringSsl::New(key);
+// EXPECT_TRUE(res.ok()) << res.status();
+// auto cipher = std::move(res.ValueOrDie());
+// std::string aad = "Additional data";
+// std::string message = "Some data to encrypt.";
+// auto ct = cipher->Encrypt(message, aad);
+// EXPECT_TRUE(ct.ok()) << ct.status();
+// auto pt = cipher->Decrypt(ct.ValueOrDie(), aad);
+// EXPECT_TRUE(pt.ok()) << pt.status();
+// EXPECT_EQ(pt.ValueOrDie(), message);
+// }
+
+// Compares the output of AesSiv to AesSivBoringSsl
+
+// Wrong key size
+
+// Null input
+
+// Null key
+
+// Different key with same string are different things
+
+// Same key with different strings are different things
+
+}  // namespace
+}  // namespace subtle
+}  // namespace tink
+}  // namespace crypto

--- a/src/test/cc/wfanet/panelmatch/common/crypto/aes_test.cc
+++ b/src/test/cc/wfanet/panelmatch/common/crypto/aes_test.cc
@@ -1,3 +1,17 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "wfanet/panelmatch/common/crypto/aes.h"
 
 #include <string>
@@ -6,9 +20,7 @@
 #include "src/test/cc/testutil/matchers.h"
 //#include "tink/util/secret_data.h"
 
-namespace crypto {
-namespace tink {
-namespace subtle {
+namespace wfanet::panelmatch::common::crypto {
 namespace {
 
 using ::crypto::tink::util::SecretDataFromStringView;
@@ -56,6 +68,4 @@ TEST(AesTest, unimplementedDecrypt) {
 // Same key with different strings are different things
 
 }  // namespace
-}  // namespace subtle
-}  // namespace tink
-}  // namespace crypto
+}  // namespace wfanet::panelmatch::common::crypto


### PR DESCRIPTION
Add pseudo-implementation for AES for encrypting user data.  AES
implementation throws an UnimplementedError due to visibility
restrictions from tink.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/36)
<!-- Reviewable:end -->
