### PR TITLE
Prepare encryption_utility_helper for common-cpp migration.

### DIFF
--- a/src/main/cc/wfanet/panelmatch/client/eventpreprocessing/BUILD.bazel
+++ b/src/main/cc/wfanet/panelmatch/client/eventpreprocessing/BUILD.bazel
@@ -9,7 +9,6 @@ cc_library(
     strip_include_prefix = "/src/main/cc",
     deps = [
         "//src/main/cc/wfanet/panelmatch/common:macros",
-        "//src/main/cc/wfanet/panelmatch/common/crypto:encryption_utility_helper",
         "//src/main/proto/wfanet/panelmatch/client/eventpreprocessing:preprocess_events_cc_proto",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/status:statusor",
@@ -24,7 +23,9 @@ cc_library(
     strip_include_prefix = "/src/main/cc",
     deps = [
         ":preprocess_events",
+        "//src/main/cc/wfanet/panelmatch/common:jni_wrap",
         "//src/main/proto/wfanet/panelmatch/client/eventpreprocessing:preprocess_events_cc_proto",
+        "@com_google_absl//absl/status:statusor",
         "@wfa_measurement_system//src/main/cc/wfa/measurement/common/crypto:encryption_utility_helper",
     ],
 )

--- a/src/main/cc/wfanet/panelmatch/client/eventpreprocessing/preprocess_events.cc
+++ b/src/main/cc/wfanet/panelmatch/client/eventpreprocessing/preprocess_events.cc
@@ -23,7 +23,6 @@
 #include "absl/strings/str_cat.h"
 #include "absl/types/span.h"
 #include "wfanet/panelmatch/client/eventpreprocessing/preprocess_events.pb.h"
-#include "wfanet/panelmatch/common/crypto/encryption_utility_helper.h"
 
 namespace wfanet::panelmatch::client {
 absl::StatusOr<PreprocessEventsResponse> PreprocessEvents(

--- a/src/main/cc/wfanet/panelmatch/client/eventpreprocessing/preprocess_events_wrapper.cc
+++ b/src/main/cc/wfanet/panelmatch/client/eventpreprocessing/preprocess_events_wrapper.cc
@@ -15,23 +15,15 @@
 
 #include <string>
 
-#include "absl/memory/memory.h"
-#include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "wfa/measurement/common/crypto/encryption_utility_helper.h"
 #include "wfanet/panelmatch/client/eventpreprocessing/preprocess_events.h"
 #include "wfanet/panelmatch/client/eventpreprocessing/preprocess_events.pb.h"
-#include "wfanet/panelmatch/common/crypto/encryption_utility_helper.h"
+#include "wfanet/panelmatch/common/jni_wrap.h"
 
 namespace wfanet::panelmatch::client {
 absl::StatusOr<std::string> PreprocessEventsWrapper(
     const std::string& serialized_request) {
-  wfanet::panelmatch::client::PreprocessEventsRequest request_proto;
-
-  RETURN_IF_ERROR(wfanet::panelmatch::common::crypto::ParseRequestFromString(
-      serialized_request, request_proto));
-  ASSIGN_OR_RETURN(PreprocessEventsResponse result,
-                   PreprocessEvents(request_proto));
-  return result.SerializeAsString();
+  return wfanet::panelmatch::common::JniWrap(serialized_request,
+                                             &PreprocessEvents);
 }
 }  // namespace wfanet::panelmatch::client

--- a/src/main/cc/wfanet/panelmatch/client/eventpreprocessing/preprocess_events_wrapper.cc
+++ b/src/main/cc/wfanet/panelmatch/client/eventpreprocessing/preprocess_events_wrapper.cc
@@ -24,6 +24,6 @@ namespace wfanet::panelmatch::client {
 absl::StatusOr<std::string> PreprocessEventsWrapper(
     const std::string& serialized_request) {
   return wfanet::panelmatch::common::JniWrap(serialized_request,
-                                             &PreprocessEvents);
+                                             PreprocessEvents);
 }
 }  // namespace wfanet::panelmatch::client

--- a/src/main/cc/wfanet/panelmatch/client/eventpreprocessing/preprocess_events_wrapper.h
+++ b/src/main/cc/wfanet/panelmatch/client/eventpreprocessing/preprocess_events_wrapper.h
@@ -19,11 +19,7 @@
 
 #include <string>
 
-#include "absl/status/status.h"
 #include "absl/status/statusor.h"
-#include "util/status_macros.h"
-#include "wfanet/panelmatch/client/eventpreprocessing/preprocess_events.pb.h"
-#include "wfanet/panelmatch/common/crypto/encryption_utility_helper.h"
 
 namespace wfanet::panelmatch::client {
 absl::StatusOr<std::string> PreprocessEventsWrapper(

--- a/src/main/cc/wfanet/panelmatch/common/BUILD.bazel
+++ b/src/main/cc/wfanet/panelmatch/common/BUILD.bazel
@@ -6,8 +6,26 @@ _INCLUDE_PREFIX = "/src/main/cc"
 
 cc_library(
     name = "macros",
-    hdrs = [
-        "macros.h",
-    ],
+    hdrs = ["macros.h"],
     strip_include_prefix = _INCLUDE_PREFIX,
+)
+
+cc_library(
+    name = "deserialize_proto",
+    hdrs = ["deserialize_proto.h"],
+    strip_include_prefix = _INCLUDE_PREFIX,
+    deps = [
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
+    name = "jni_wrap",
+    hdrs = ["jni_wrap.h"],
+    strip_include_prefix = _INCLUDE_PREFIX,
+    deps = [
+        ":deserialize_proto",
+        ":macros",
+        "@com_google_absl//absl/status:statusor",
+    ],
 )

--- a/src/main/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
@@ -51,17 +51,6 @@ cc_library(
 )
 
 cc_library(
-    name = "encryption_utility_helper",
-    hdrs = [
-        "encryption_utility_helper.h",
-    ],
-    strip_include_prefix = _INCLUDE_PREFIX,
-    deps = [
-        "@com_google_absl//absl/status:statusor",
-    ],
-)
-
-cc_library(
     name = "hkdf",
     srcs = [
         "hkdf.cc",

--- a/src/main/cc/wfanet/panelmatch/common/deserialize_proto.h
+++ b/src/main/cc/wfanet/panelmatch/common/deserialize_proto.h
@@ -12,25 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_CRYPTO_ENCRYPTION_UTILITY_HELPER_H_
-#define SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_CRYPTO_ENCRYPTION_UTILITY_HELPER_H_
+#ifndef SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_DESERIALIZE_PROTO_H_
+#define SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_DESERIALIZE_PROTO_H_
 
 #include <string>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 
-namespace wfanet::panelmatch::common::crypto {
+namespace wfanet::panelmatch::common {
 
+// Parses `serialized_proto` into a T.
 template <typename T>
-absl::Status ParseRequestFromString(const std::string& serialized_request,
-                                    T& request_proto) {
-  return request_proto.ParseFromString(serialized_request)
-             ? absl::OkStatus()
-             : absl::InternalError(
-                   "failed to parse the serialized request proto.");
+absl::StatusOr<T> DeserializeProto(const std::string& serialized_proto) {
+  T proto;
+  if (!proto.ParseFromString(serialized_proto)) {
+    return absl::InternalError("Failed to parse serialized proto.");
+  }
+  return proto;
 }
 
-}  // namespace wfanet::panelmatch::common::crypto
+}  // namespace wfanet::panelmatch::common
 
-#endif  // SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_CRYPTO_ENCRYPTION_UTILITY_HELPER_H_
+#endif  // SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_DESERIALIZE_PROTO_H_

--- a/src/main/cc/wfanet/panelmatch/common/jni_wrap.h
+++ b/src/main/cc/wfanet/panelmatch/common/jni_wrap.h
@@ -25,8 +25,8 @@
 
 namespace wfanet::panelmatch::common {
 
-// Deseriales `serialized_request`, then calls `inner_function` on the resulting
-// proto, then serializes and returns the result.
+// Deserializes `serialized_request`, then calls `inner_function` on the
+// resulting proto, then serializes and returns the result.
 template <typename Request, typename Response>
 absl::StatusOr<std::string> JniWrap(
     const std::string& serialized_request,

--- a/src/main/cc/wfanet/panelmatch/common/jni_wrap.h
+++ b/src/main/cc/wfanet/panelmatch/common/jni_wrap.h
@@ -17,6 +17,8 @@
 #ifndef SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_JNI_WRAP_H_
 #define SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_JNI_WRAP_H_
 
+#include <string>
+
 #include "absl/status/statusor.h"
 #include "util/status_macros.h"
 #include "wfanet/panelmatch/common/deserialize_proto.h"

--- a/src/main/cc/wfanet/panelmatch/common/jni_wrap.h
+++ b/src/main/cc/wfanet/panelmatch/common/jni_wrap.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_JNI_WRAP_H_
+#define SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_JNI_WRAP_H_
+
+#include "absl/status/statusor.h"
+#include "util/status_macros.h"
+#include "wfanet/panelmatch/common/deserialize_proto.h"
+
+namespace wfanet::panelmatch::common {
+
+// Deseriales `serialized_request`, then calls `inner_function` on the resulting
+// proto, then serializes and returns the result.
+template <typename Request, typename Response>
+absl::StatusOr<std::string> JniWrap(
+    const std::string& serialized_request,
+    absl::StatusOr<Response> (*inner_function)(const Request&)) {
+  ASSIGN_OR_RETURN(auto request, DeserializeProto<Request>(serialized_request));
+  ASSIGN_OR_RETURN(Response response, inner_function(request));
+  return response.SerializeAsString();
+}
+
+}  // namespace wfanet::panelmatch::common
+
+#endif  // SRC_MAIN_CC_WFANET_PANELMATCH_COMMON_JNI_WRAP_H_

--- a/src/main/cc/wfanet/panelmatch/protocol/crypto/BUILD.bazel
+++ b/src/main/cc/wfanet/panelmatch/protocol/crypto/BUILD.bazel
@@ -16,7 +16,6 @@ cc_library(
     deps = [
         "//src/main/cc/wfanet/panelmatch/common:macros",
         "//src/main/cc/wfanet/panelmatch/common/crypto:cryptor",
-        "//src/main/cc/wfanet/panelmatch/common/crypto:encryption_utility_helper",
         "//src/main/proto/wfanet/panelmatch/protocol/crypto:cryptor_cc_proto",
         "@wfa_measurement_system//src/main/cc/wfa/measurement/common/crypto:started_thread_cpu_timer",
     ],
@@ -33,6 +32,7 @@ cc_library(
     strip_include_prefix = _INCLUDE_PREFIX,
     deps = [
         ":deterministic_commutative_encryption_utility",
+        "//src/main/cc/wfanet/panelmatch/common:jni_wrap",
         "//src/main/proto/wfanet/panelmatch/protocol/crypto:cryptor_cc_proto",
     ],
 )

--- a/src/main/cc/wfanet/panelmatch/protocol/crypto/deterministic_commutative_encryption_utility.cc
+++ b/src/main/cc/wfanet/panelmatch/protocol/crypto/deterministic_commutative_encryption_utility.cc
@@ -14,8 +14,6 @@
 
 #include "wfanet/panelmatch/protocol/crypto/deterministic_commutative_encryption_utility.h"
 
-#include <wfa/measurement/common/crypto/started_thread_cpu_timer.h>
-
 #include <algorithm>
 #include <string>
 #include <utility>
@@ -27,18 +25,15 @@
 #include "absl/strings/str_cat.h"
 #include "absl/types/span.h"
 #include "util/status_macros.h"
+#include "wfa/measurement/common/crypto/started_thread_cpu_timer.h"
 #include "wfanet/panelmatch/common/crypto/cryptor.h"
-#include "wfanet/panelmatch/common/crypto/encryption_utility_helper.h"
 #include "wfanet/panelmatch/common/macros.h"
 #include "wfanet/panelmatch/protocol/crypto/cryptor.pb.h"
 
 namespace wfanet::panelmatch::protocol::crypto {
-
 namespace {
-
 using ::wfanet::panelmatch::common::crypto::Action;
 using ::wfanet::panelmatch::common::crypto::CreateCryptorFromKey;
-
 }  // namespace
 
 absl::StatusOr<wfanet::panelmatch::protocol::protobuf::CryptorEncryptResponse>

--- a/src/main/cc/wfanet/panelmatch/protocol/crypto/deterministic_commutative_encryption_utility_wrapper.cc
+++ b/src/main/cc/wfanet/panelmatch/protocol/crypto/deterministic_commutative_encryption_utility_wrapper.cc
@@ -21,12 +21,6 @@
 
 namespace wfanet::panelmatch::protocol::crypto {
 using ::wfanet::panelmatch::common::JniWrap;
-using ::wfanet::panelmatch::protocol::protobuf::CryptorDecryptRequest;
-using ::wfanet::panelmatch::protocol::protobuf::CryptorDecryptResponse;
-using ::wfanet::panelmatch::protocol::protobuf::CryptorEncryptRequest;
-using ::wfanet::panelmatch::protocol::protobuf::CryptorEncryptResponse;
-using ::wfanet::panelmatch::protocol::protobuf::CryptorReEncryptRequest;
-using ::wfanet::panelmatch::protocol::protobuf::CryptorReEncryptResponse;
 
 absl::StatusOr<std::string> DeterministicCommutativeEncryptWrapper(
     const std::string& serialized_request) {

--- a/src/main/cc/wfanet/panelmatch/protocol/crypto/deterministic_commutative_encryption_utility_wrapper.cc
+++ b/src/main/cc/wfanet/panelmatch/protocol/crypto/deterministic_commutative_encryption_utility_wrapper.cc
@@ -14,46 +14,33 @@
 
 #include "wfanet/panelmatch/protocol/crypto/deterministic_commutative_encryption_utility_wrapper.h"
 
-#include "absl/memory/memory.h"
 #include "absl/status/statusor.h"
-#include "util/status_macros.h"
-#include "wfanet/panelmatch/common/crypto/encryption_utility_helper.h"
+#include "wfanet/panelmatch/common/jni_wrap.h"
 #include "wfanet/panelmatch/protocol/crypto/cryptor.pb.h"
 #include "wfanet/panelmatch/protocol/crypto/deterministic_commutative_encryption_utility.h"
 
 namespace wfanet::panelmatch::protocol::crypto {
+using ::wfanet::panelmatch::common::JniWrap;
+using ::wfanet::panelmatch::protocol::protobuf::CryptorDecryptRequest;
+using ::wfanet::panelmatch::protocol::protobuf::CryptorDecryptResponse;
+using ::wfanet::panelmatch::protocol::protobuf::CryptorEncryptRequest;
+using ::wfanet::panelmatch::protocol::protobuf::CryptorEncryptResponse;
+using ::wfanet::panelmatch::protocol::protobuf::CryptorReEncryptRequest;
+using ::wfanet::panelmatch::protocol::protobuf::CryptorReEncryptResponse;
 
 absl::StatusOr<std::string> DeterministicCommutativeEncryptWrapper(
     const std::string& serialized_request) {
-  wfanet::panelmatch::protocol::protobuf::CryptorEncryptRequest request_proto;
-  RETURN_IF_ERROR(wfanet::panelmatch::common::crypto::ParseRequestFromString(
-      serialized_request, request_proto));
-  ASSIGN_OR_RETURN(
-      wfanet::panelmatch::protocol::protobuf::CryptorEncryptResponse result,
-      DeterministicCommutativeEncrypt(request_proto));
-  return result.SerializeAsString();
+  return JniWrap(serialized_request, DeterministicCommutativeEncrypt);
 }
 
 absl::StatusOr<std::string> DeterministicCommutativeReEncryptWrapper(
     const std::string& serialized_request) {
-  wfanet::panelmatch::protocol::protobuf::CryptorReEncryptRequest request_proto;
-  RETURN_IF_ERROR(wfanet::panelmatch::common::crypto::ParseRequestFromString(
-      serialized_request, request_proto));
-  ASSIGN_OR_RETURN(
-      wfanet::panelmatch::protocol::protobuf::CryptorReEncryptResponse result,
-      DeterministicCommutativeReEncrypt(request_proto));
-  return result.SerializeAsString();
+  return JniWrap(serialized_request, DeterministicCommutativeReEncrypt);
 }
 
 absl::StatusOr<std::string> DeterministicCommutativeDecryptWrapper(
     const std::string& serialized_request) {
-  wfanet::panelmatch::protocol::protobuf::CryptorDecryptRequest request_proto;
-  RETURN_IF_ERROR(wfanet::panelmatch::common::crypto::ParseRequestFromString(
-      serialized_request, request_proto));
-  ASSIGN_OR_RETURN(
-      wfanet::panelmatch::protocol::protobuf::CryptorDecryptResponse result,
-      DeterministicCommutativeDecrypt(request_proto));
-  return result.SerializeAsString();
+  return JniWrap(serialized_request, DeterministicCommutativeDecrypt);
 }
 
 }  // namespace wfanet::panelmatch::protocol::crypto

--- a/src/main/cc/wfanet/panelmatch/protocol/crypto/deterministic_commutative_encryption_utility_wrapper.h
+++ b/src/main/cc/wfanet/panelmatch/protocol/crypto/deterministic_commutative_encryption_utility_wrapper.h
@@ -18,8 +18,6 @@
 #include <string>
 
 #include "absl/status/statusor.h"
-#include "wfanet/panelmatch/common/crypto/encryption_utility_helper.h"
-#include "wfanet/panelmatch/protocol/crypto/cryptor.pb.h"
 
 // Wrapper methods used to generate the swig/JNI Java classes.
 // The only functionality of these methods are converting between proto messages


### PR DESCRIPTION
This moves it into the //src/main/cc/wfanet/panelmatch/common Bazel
package, which can be migrated entirely to the common-cpp repo.

This also refactors some redundant code to use a helper library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/38)
<!-- Reviewable:end -->
