### PR TITLE
Add implementation to Aes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -317,9 +317,9 @@ tink_cc_deps_init()
 # Common-cpp
 http_archive(
     name = "wfa_common_cpp",
-    sha256 = "fc33c81ade972199fde949a18f8b8483b67e5458ee6a08dc7d905bfdbade41d4",
-    strip_prefix = "common-cpp-ec6e107b0509f074145b1b7751c22f5f9e0e2117",
-    url = "https://github.com/world-federation-of-advertisers/common-cpp/archive/ec6e107b0509f074145b1b7751c22f5f9e0e2117.tar.gz",
+    sha256 = "e0e1f5eed832ef396109354a64c6c1306bf0fb5ea0b449ce6ee1e8edc6fe279d",
+    strip_prefix = "common-cpp-43c75acc3394e19bcfd2cfe8e8e2454365d26d60",
+    url = "https://github.com/world-federation-of-advertisers/common-cpp/archive/43c75acc3394e19bcfd2cfe8e8e2454365d26d60.tar.gz",
 )
 
 load("@wfa_common_cpp//build:deps.bzl", "common_cpp_deps")

--- a/src/main/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
@@ -18,6 +18,8 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@tink_base//cc/util:secret_data",
+        "@tink_cc//subtle",
+        "@wfa_common_cpp//src/main/cc/common_cpp/macros",
     ],
 )
 

--- a/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
@@ -14,6 +14,9 @@
 
 #include "wfanet/panelmatch/common/crypto/aes.h"
 
+#include <memory>
+#include <string>
+
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"

--- a/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/aes.cc
@@ -15,10 +15,17 @@
 #include "wfanet/panelmatch/common/crypto/aes.h"
 
 #include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "common_cpp/macros/macros.h"
+#include "tink/subtle/aes_siv_boringssl.h"
+#include "tink/util/secret_data.h"
 
 namespace wfanet::panelmatch::common::crypto {
 namespace {
 
+using ::crypto::tink::DeterministicAead;
+using ::crypto::tink::subtle::AesSivBoringSsl;
 using ::crypto::tink::util::SecretData;
 
 // Implements an Aes SIV encryption scheme defined in
@@ -29,12 +36,16 @@ class AesSiv : public Aes {
 
   absl::StatusOr<std::string> Encrypt(absl::string_view input,
                                       const SecretData& key) const override {
-    return absl::UnimplementedError("Not implemented");
+    ASSIGN_OR_RETURN(std::unique_ptr<DeterministicAead> aes,
+                     AesSivBoringSsl::New(key));
+    return aes->EncryptDeterministically(input, "");
   }
 
   absl::StatusOr<std::string> Decrypt(absl::string_view input,
                                       const SecretData& key) const override {
-    return absl::UnimplementedError("Not implemented");
+    ASSIGN_OR_RETURN(std::unique_ptr<DeterministicAead> aes,
+                     AesSivBoringSsl::New(key));
+    return aes->DecryptDeterministically(input, "");
   }
 
   int32_t key_size_bytes() const override { return 64; }

--- a/src/main/cc/wfanet/panelmatch/common/crypto/aes.h
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/aes.h
@@ -45,7 +45,7 @@ class Aes {
       absl::string_view input,
       const ::crypto::tink::util::SecretData& key) const = 0;
 
-  // Returns byte size for Aes key
+  // Returns required byte size for Aes key
   virtual int32_t key_size_bytes() const = 0;
 };
 

--- a/src/main/cc/wfanet/panelmatch/common/crypto/aes.h
+++ b/src/main/cc/wfanet/panelmatch/common/crypto/aes.h
@@ -30,12 +30,14 @@ namespace wfanet::panelmatch::common::crypto {
 class Aes {
  public:
   virtual ~Aes() = default;
+
   // Encrypts `input` using AES key `key`
   // This will return an error status if the key is the wrong size for the
   // given AES implementation
   virtual absl::StatusOr<std::string> Encrypt(
       absl::string_view input,
       const ::crypto::tink::util::SecretData& key) const = 0;
+
   // Decrypts `input` using AES key `key`
   // This will return an error status if the key is the wrong size for the
   // given AES implementation
@@ -43,6 +45,7 @@ class Aes {
       absl::string_view input,
       const ::crypto::tink::util::SecretData& key) const = 0;
 
+  // Returns byte size for Aes key
   virtual int32_t key_size_bytes() const = 0;
 };
 

--- a/src/test/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
+++ b/src/test/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
@@ -20,6 +20,8 @@ cc_test(
         "//src/test/cc/testutil:matchers",
         "@com_google_absl//absl/strings",
         "@googletest//:gtest_main",
+        "@tink_base//cc/util:secret_data",
+        "@tink_cc//subtle",
     ],
 )
 
@@ -49,6 +51,7 @@ cc_test(
         "//src/main/cc/wfanet/panelmatch/common/crypto:aes_with_hkdf",
         "//src/test/cc/testutil:matchers",
         "//src/test/cc/testutil:status_macros",
+        "@com_google_absl//absl/strings",
         "@googletest//:gtest_main",
     ],
 )

--- a/src/test/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
+++ b/src/test/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
@@ -18,6 +18,7 @@ cc_test(
     deps = [
         "//src/main/cc/wfanet/panelmatch/common/crypto:aes",
         "//src/test/cc/testutil:matchers",
+        "//src/test/cc/testutil:status_macros",
         "@com_google_absl//absl/strings",
         "@googletest//:gtest_main",
         "@tink_base//cc/util:secret_data",

--- a/src/test/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
+++ b/src/test/cc/wfanet/panelmatch/common/crypto/BUILD.bazel
@@ -17,12 +17,11 @@ cc_test(
     srcs = ["aes_test.cc"],
     deps = [
         "//src/main/cc/wfanet/panelmatch/common/crypto:aes",
-        "//src/test/cc/testutil:matchers",
-        "//src/test/cc/testutil:status_macros",
         "@com_google_absl//absl/strings",
         "@googletest//:gtest_main",
         "@tink_base//cc/util:secret_data",
         "@tink_cc//subtle",
+        "@wfa_common_cpp//src/main/cc/common_cpp/testing:status",
     ],
 )
 
@@ -50,10 +49,9 @@ cc_test(
     ],
     deps = [
         "//src/main/cc/wfanet/panelmatch/common/crypto:aes_with_hkdf",
-        "//src/test/cc/testutil:matchers",
-        "//src/test/cc/testutil:status_macros",
         "@com_google_absl//absl/strings",
         "@googletest//:gtest_main",
+        "@wfa_common_cpp//src/main/cc/common_cpp/testing:status",
     ],
 )
 

--- a/src/test/cc/wfanet/panelmatch/common/crypto/aes_test.cc
+++ b/src/test/cc/wfanet/panelmatch/common/crypto/aes_test.cc
@@ -16,34 +16,183 @@
 
 #include <string>
 
+#include "absl/strings/escaping.h"
 #include "gtest/gtest.h"
 #include "src/test/cc/testutil/matchers.h"
+#include "tink/subtle/aes_siv_boringssl.h"
+#include "tink/util/secret_data.h"
 
 namespace wfanet::panelmatch::common::crypto {
 namespace {
 
+using ::crypto::tink::subtle::AesSivBoringSsl;
+using ::crypto::tink::util::SecretData;
 using ::crypto::tink::util::SecretDataFromStringView;
 
-TEST(AesTest, unimplementedEncrypt) {
+// Tests that a value encrypted then decrypted returns that original value
+// Key values for these tests are found at
+// tink/cc/subtle/aes_siv_boringssl_test.cc
+TEST(AesTest, testEncryptDecrypt) {
   std::unique_ptr<Aes> aes = GetAesSivCmac512();
-  auto result = aes->Encrypt("input", SecretDataFromStringView("key"));
-  EXPECT_THAT(result.status(), StatusIs(absl::StatusCode::kUnimplemented, ""));
+  SecretData key = SecretDataFromStringView(absl::HexStringToBytes(
+      "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+      "00112233445566778899aabbccddeefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"));
+  std::string_view message = "Some data to encrypt.";
+  auto encrypted = aes->Encrypt(message, key);
+  ASSERT_TRUE(encrypted.ok()) << encrypted.status();
+  auto reverted = aes->Decrypt(*encrypted, key);
+  ASSERT_TRUE(reverted.ok()) << reverted.status();
+  EXPECT_EQ(*reverted, message);
 }
 
-TEST(AesTest, unimplementedDecrypt) {
-  std::unique_ptr<Aes> aes = GetAesSivCmac512();
-  auto result = aes->Decrypt("input", SecretDataFromStringView("key"));
-  EXPECT_THAT(result.status(), StatusIs(absl::StatusCode::kUnimplemented, ""));
+// Tests that AesSiv Encrypt returns the same value as AesSivBoringSsl
+// EncryptDeterministically
+TEST(AesTest, compareEncrypt) {
+  std::unique_ptr<Aes> aes_this = GetAesSivCmac512();
+  SecretData key = SecretDataFromStringView(absl::HexStringToBytes(
+      "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+      "00112233445566778899aabbccddeefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"));
+  auto aes_other = AesSivBoringSsl::New(key);
+  ASSERT_TRUE(aes_other.ok()) << aes_other.status();
+  std::string message = "Some data to encrypt.";
+  auto result_this = aes_this->Encrypt(message, key);
+  auto result_other = (*aes_other)->EncryptDeterministically(message, "");
+  ASSERT_TRUE(result_other.ok()) << result_other.status();
+  EXPECT_THAT(result_this, result_other);
 }
 
-// TODO(efreck): Implement the following test cases
-//  - Encrypt/Decrypt
-//  - Compares the output of AesSiv to AesSivBoringSsl
-//  - Wrong key size
-//  - Null input
-//  - Null key
-//  - Different key with same string are different things
-//  - Same key with different strings are different things
+// Tests that AesSiv Decrypt returns the same value as AesSivBoringSsl
+// DecryptDeterministically
+TEST(AesTest, compareDecrypt) {
+  std::unique_ptr<Aes> aes_this = GetAesSivCmac512();
+  SecretData key = SecretDataFromStringView(absl::HexStringToBytes(
+      "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+      "00112233445566778899aabbccddeefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"));
+  auto aes_other = AesSivBoringSsl::New(key);
+  ASSERT_TRUE(aes_other.ok()) << aes_other.status();
+  std::string message = "Some data to encrypt.";
+  auto encrypted = aes_this->Encrypt(message, key);
+  auto result_this = aes_this->Decrypt(*encrypted, key);
+  auto result_other = (*aes_other)->DecryptDeterministically(*encrypted, "");
+  ASSERT_TRUE(result_other.ok()) << result_other.status();
+  EXPECT_THAT(*result_this, *result_other);
+}
+
+// Tests that AesSiv Encrypt returns an error with the wrong key size
+TEST(AesTest, wrongKeySizeEncrypt) {
+  std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key = SecretDataFromStringView(absl::HexStringToBytes("01"));
+  auto result = aes->Encrypt("input", key);
+  EXPECT_THAT(result.status(),
+              StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
+// Tests that AesSiv Decrypt returns an error with the wrong key size
+TEST(AesTest, wrongKeySizeDecrypt) {
+  std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key = SecretDataFromStringView(absl::HexStringToBytes(
+      "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+      "00112233445566778899aabbccddeefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"));
+  std::string message = "Some data to encrypt.";
+  auto encrypted = aes->Encrypt(message, key);
+  key = ::crypto::tink::util::SecretDataFromStringView(
+      absl::HexStringToBytes("01"));
+  auto result = aes->Decrypt(*encrypted, key);
+  EXPECT_THAT(result.status(),
+              StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
+// Tests that AesSiv Encrypt returns an error with an empty key
+TEST(AesTest, emptyKeyEncrypt) {
+  std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key = SecretDataFromStringView(absl::HexStringToBytes(""));
+  auto result = aes->Encrypt("input", key);
+  EXPECT_THAT(result.status(),
+              StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
+// Tests that AesSiv Decrypt returns an error with an empty key
+TEST(AesTest, emptyKeyDecrypt) {
+  std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key = SecretDataFromStringView(absl::HexStringToBytes(
+      "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+      "00112233445566778899aabbccddeefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"));
+  std::string message = "Some data to encrypt.";
+  auto encrypted = aes->Encrypt(message, key);
+  key = ::crypto::tink::util::SecretDataFromStringView(
+      absl::HexStringToBytes(""));
+  auto result = aes->Decrypt(*encrypted, key);
+  EXPECT_THAT(result.status(),
+              StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
+// Tests that different keys with the same string return different values
+TEST(AesTest, differentKeySameStringEncrypt) {
+  std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key_1 = SecretDataFromStringView(absl::HexStringToBytes(
+      "990102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+      "99112233445566778899aabbccddeefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"));
+  SecretData key_2 = SecretDataFromStringView(absl::HexStringToBytes(
+      "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+      "00112233445566778899aabbccddeefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"));
+  std::string_view message = "Some data to encrypt.";
+  auto encrypted_1 = aes->Encrypt(message, key_1);
+  auto encrypted_2 = aes->Encrypt(message, key_2);
+  ASSERT_TRUE(encrypted_1.ok()) << encrypted_1.status();
+  ASSERT_TRUE(encrypted_2.ok()) << encrypted_2.status();
+  EXPECT_NE(*encrypted_1, *encrypted_2);
+}
+
+// Tests that decrypting with a different key than encryption gives an error
+TEST(AesTest, differentKeyDecrypt) {
+  std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key_1 = SecretDataFromStringView(absl::HexStringToBytes(
+      "990102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+      "99112233445566778899aabbccddeefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"));
+  SecretData key_2 = SecretDataFromStringView(absl::HexStringToBytes(
+      "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+      "00112233445566778899aabbccddeefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"));
+  std::string_view message = "Some data to encrypt.";
+  auto encrypted = aes->Encrypt(message, key_1);
+  ASSERT_TRUE(encrypted.ok()) << encrypted.status();
+  auto decrypted = aes->Decrypt(*encrypted, key_2);
+  EXPECT_THAT(decrypted.status(),
+              StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
+// Tests that the same key with different strings return different values
+TEST(AesTest, sameKeyDiffernetStringEncrypt) {
+  std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key = SecretDataFromStringView(absl::HexStringToBytes(
+      "990102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+      "99112233445566778899aabbccddeefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"));
+  std::string_view message_1 = "Some data to encrypt.";
+  std::string_view message_2 = "Additional data to encrypt.";
+  auto encrypted_1 = aes->Encrypt(message_1, key);
+  auto encrypted_2 = aes->Encrypt(message_2, key);
+  EXPECT_TRUE(encrypted_1.ok()) << encrypted_1.status();
+  EXPECT_TRUE(encrypted_2.ok()) << encrypted_2.status();
+  EXPECT_NE(*encrypted_1, *encrypted_2);
+}
+
+// Tests that the same key with different strings return different values
+TEST(AesTest, sameKeyDiffernetStringDecrypt) {
+  std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key = SecretDataFromStringView(absl::HexStringToBytes(
+      "990102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+      "99112233445566778899aabbccddeefff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"));
+  std::string_view message_1 = "Some data to encrypt.";
+  std::string_view message_2 = "Additional data to encrypt.";
+  auto encrypted_1 = aes->Encrypt(message_1, key);
+  auto encrypted_2 = aes->Encrypt(message_2, key);
+  ASSERT_TRUE(encrypted_1.ok()) << encrypted_1.status();
+  ASSERT_TRUE(encrypted_2.ok()) << encrypted_2.status();
+  auto decrypted_1 = aes->Decrypt(*encrypted_1, key);
+  auto decrypted_2 = aes->Decrypt(*encrypted_2, key);
+  ASSERT_TRUE(decrypted_1.ok()) << decrypted_1.status();
+  ASSERT_TRUE(decrypted_2.ok()) << decrypted_2.status();
+  EXPECT_NE(*decrypted_1, *decrypted_2);
+}
 
 }  // namespace
 }  // namespace wfanet::panelmatch::common::crypto

--- a/src/test/cc/wfanet/panelmatch/common/crypto/aes_with_hkdf_test.cc
+++ b/src/test/cc/wfanet/panelmatch/common/crypto/aes_with_hkdf_test.cc
@@ -14,6 +14,7 @@
 
 #include "wfanet/panelmatch/common/crypto/aes_with_hkdf.h"
 
+#include "absl/strings/escaping.h"
 #include "gtest/gtest.h"
 #include "src/test/cc/testutil/matchers.h"
 #include "src/test/cc/testutil/status_macros.h"
@@ -21,26 +22,57 @@
 namespace wfanet::panelmatch::common::crypto {
 namespace {
 
+using ::crypto::tink::util::SecretData;
 using ::crypto::tink::util::SecretDataFromStringView;
 
-// Test with proper key and proper input - Encrypt
-// Not currently implemented
-TEST(AesWithHkdfTest, unimplementedEncrypt) {
+// Tests that a value encrypted then decrypted returns that original value
+TEST(AesWithHkdfTest, testEncryptDecrypt) {
   std::unique_ptr<Hkdf> hkdf = GetSha256Hkdf();
   std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key = SecretDataFromStringView("key");
+  std::string_view message = "Some data to encrypt.";
   AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
-  auto result = aes_hkdf.Encrypt("input", SecretDataFromStringView("key"));
-  EXPECT_THAT(result.status(), StatusIs(absl::StatusCode::kUnimplemented, ""));
+  auto encrypted = aes_hkdf.Encrypt(message, key);
+  ASSERT_TRUE(encrypted.ok()) << encrypted.status();
+  auto decrypted = aes_hkdf.Decrypt(*encrypted, key);
+  ASSERT_TRUE(decrypted.ok()) << decrypted.status();
+  EXPECT_EQ(*decrypted, message);
 }
 
-// Test with proper key and proper input - Encrypt
-// Not currently implemented
-TEST(AesWithHkdfTest, unimplementedDecrypt) {
+// Tests that the result of AesWithHkdf Encrypt is the same as the result
+// of the functions called within it
+TEST(AesWithHkdfTest, compareEncrypt) {
   std::unique_ptr<Hkdf> hkdf = GetSha256Hkdf();
   std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key = SecretDataFromStringView("key");
+  std::string_view message = "Some data to encrypt.";
+  auto result = hkdf->ComputeHkdf(key, aes->key_size_bytes());
+  ASSERT_TRUE(result.ok()) << result.status();
+  auto encrypted_other = aes->Encrypt(message, *result);
   AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
-  auto result = aes_hkdf.Decrypt("input", SecretDataFromStringView("key"));
-  EXPECT_THAT(result.status(), StatusIs(absl::StatusCode::kUnimplemented, ""));
+  auto encrypted_this = aes_hkdf.Encrypt(message, key);
+  ASSERT_TRUE(encrypted_this.ok()) << encrypted_this.status();
+  EXPECT_EQ(*encrypted_this, *encrypted_other);
+}
+
+// Tests that the result of AesWithHkdf Decrypt is the same as the result
+// of the functions called within it
+TEST(AesWithHkdfTest, compareDecrypt) {
+  std::unique_ptr<Hkdf> hkdf = GetSha256Hkdf();
+  std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key = SecretDataFromStringView("key");
+  std::string_view message = "Some data to encrypt.";
+  auto result = hkdf->ComputeHkdf(key, aes->key_size_bytes());
+  ASSERT_TRUE(result.ok()) << result.status();
+  auto encrypted_other = aes->Encrypt(message, *result);
+  auto decrypted_other = aes->Decrypt(*encrypted_other, *result);
+  ASSERT_TRUE(decrypted_other.ok()) << decrypted_other.status();
+  AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
+  auto encrypted_this = aes_hkdf.Encrypt(message, key);
+  ASSERT_TRUE(encrypted_this.ok()) << encrypted_this.status();
+  auto decrypted_this = aes_hkdf.Decrypt(*encrypted_this, key);
+  ASSERT_TRUE(decrypted_this.ok()) << decrypted_this.status();
+  EXPECT_EQ(*decrypted_this, *decrypted_other);
 }
 
 // Test with empty key and proper input - Encrypt
@@ -63,11 +95,69 @@ TEST(AesWithHkdfTest, emptyKeyDecrypt) {
               StatusIs(absl::StatusCode::kInvalidArgument, ""));
 }
 
-// TODO(enfreck): Implement the following cases
-//  - Encrypt/Decrypt
-//  - Null input
-//  - Different key with same string are different things
-//  - Same key with different strings are different things
+// Tests that different keys with the same string return different values
+TEST(AesTest, differentKeySameStringEncrypt) {
+  std::unique_ptr<Hkdf> hkdf = GetSha256Hkdf();
+  std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key_1 = SecretDataFromStringView("key1");
+  SecretData key_2 = SecretDataFromStringView("key2");
+  std::string_view message = "Some data to encrypt.";
+  AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
+  auto encrypted_1 = aes_hkdf.Encrypt(message, key_1);
+  auto encrypted_2 = aes_hkdf.Encrypt(message, key_2);
+  ASSERT_TRUE(encrypted_1.ok()) << encrypted_1.status();
+  ASSERT_TRUE(encrypted_2.ok()) << encrypted_2.status();
+  EXPECT_NE(*encrypted_1, *encrypted_2);
+}
+
+// Tests that decrypting with a different key than encryption gives an error
+TEST(AesTest, differentKeyDecrypt) {
+  std::unique_ptr<Hkdf> hkdf = GetSha256Hkdf();
+  std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key_1 = SecretDataFromStringView("key1");
+  SecretData key_2 = SecretDataFromStringView("key2");
+  std::string_view message = "Some data to encrypt.";
+  AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
+  auto encrypted = aes_hkdf.Encrypt(message, key_1);
+  ASSERT_TRUE(encrypted.ok()) << encrypted.status();
+  auto decrypted = aes_hkdf.Decrypt(*encrypted, key_2);
+  EXPECT_THAT(decrypted.status(),
+              StatusIs(absl::StatusCode::kInvalidArgument, ""));
+}
+
+// Tests that the same key with different strings return different values
+TEST(AesTest, sameKeyDiffernetStringEncrypt) {
+  std::unique_ptr<Hkdf> hkdf = GetSha256Hkdf();
+  std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key = SecretDataFromStringView("key");
+  std::string_view message_1 = "Some data to encrypt.";
+  std::string_view message_2 = "Additional data to encrypt.";
+  AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
+  auto encrypted_1 = aes_hkdf.Encrypt(message_1, key);
+  auto encrypted_2 = aes_hkdf.Encrypt(message_2, key);
+  EXPECT_TRUE(encrypted_1.ok()) << encrypted_1.status();
+  EXPECT_TRUE(encrypted_2.ok()) << encrypted_2.status();
+  EXPECT_NE(*encrypted_1, *encrypted_2);
+}
+
+// Tests that the same key with different strings return different values
+TEST(AesTest, sameKeyDiffernetStringDecrypt) {
+  std::unique_ptr<Hkdf> hkdf = GetSha256Hkdf();
+  std::unique_ptr<Aes> aes = GetAesSivCmac512();
+  SecretData key = SecretDataFromStringView("key");
+  std::string_view message_1 = "Some data to encrypt.";
+  std::string_view message_2 = "Additional data to encrypt.";
+  AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
+  auto encrypted_1 = aes_hkdf.Encrypt(message_1, key);
+  auto encrypted_2 = aes_hkdf.Encrypt(message_2, key);
+  ASSERT_TRUE(encrypted_1.ok()) << encrypted_1.status();
+  ASSERT_TRUE(encrypted_2.ok()) << encrypted_2.status();
+  auto decrypted_1 = aes_hkdf.Decrypt(*encrypted_1, key);
+  auto decrypted_2 = aes_hkdf.Decrypt(*encrypted_2, key);
+  ASSERT_TRUE(decrypted_1.ok()) << decrypted_1.status();
+  ASSERT_TRUE(decrypted_2.ok()) << decrypted_2.status();
+  EXPECT_NE(*decrypted_1, *decrypted_2);
+}
 
 }  // namespace
 }  // namespace wfanet::panelmatch::common::crypto

--- a/src/test/cc/wfanet/panelmatch/common/crypto/aes_with_hkdf_test.cc
+++ b/src/test/cc/wfanet/panelmatch/common/crypto/aes_with_hkdf_test.cc
@@ -16,8 +16,9 @@
 
 #include "absl/strings/escaping.h"
 #include "gtest/gtest.h"
-#include "src/test/cc/testutil/matchers.h"
-#include "src/test/cc/testutil/status_macros.h"
+//#include "src/test/cc/testutil/matchers.h"
+#include "src/main/cc/common_cpp/testing/status_macros.h"
+#include "src/main/cc/common_cpp/testing/status_matchers.h"
 
 namespace wfanet::panelmatch::common::crypto {
 namespace {
@@ -25,17 +26,17 @@ namespace {
 using ::crypto::tink::util::SecretData;
 using ::crypto::tink::util::SecretDataFromStringView;
 
-// Tests that a value cyphertext then decrypted returns that original value
+// Tests that a value ciphertext then decrypted returns that original value
 TEST(AesWithHkdfTest, testEncryptDecrypt) {
   std::unique_ptr<Hkdf> hkdf = GetSha256Hkdf();
   std::unique_ptr<Aes> aes = GetAesSivCmac512();
   SecretData key = SecretDataFromStringView("key");
   std::string_view plaintext = "Some data to encrypt.";
   AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
-  ASSERT_OK_AND_ASSIGN(std::string cyphertext,
+  ASSERT_OK_AND_ASSIGN(std::string ciphertext,
                        aes_hkdf.Encrypt(plaintext, key));
   ASSERT_OK_AND_ASSIGN(std::string recovered_plaintext,
-                       aes_hkdf.Decrypt(cyphertext, key));
+                       aes_hkdf.Decrypt(ciphertext, key));
   EXPECT_EQ(recovered_plaintext, plaintext);
 }
 
@@ -48,12 +49,12 @@ TEST(AesWithHkdfTest, compareEncrypt) {
   std::string_view plaintext = "Some data to encrypt.";
   ASSERT_OK_AND_ASSIGN(SecretData result,
                        hkdf->ComputeHkdf(key, aes->key_size_bytes()));
-  ASSERT_OK_AND_ASSIGN(std::string cyphertext_other,
+  ASSERT_OK_AND_ASSIGN(std::string ciphertext_other,
                        aes->Encrypt(plaintext, result));
   AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
-  ASSERT_OK_AND_ASSIGN(std::string cyphertext_this,
+  ASSERT_OK_AND_ASSIGN(std::string ciphertext_this,
                        aes_hkdf.Encrypt(plaintext, key));
-  EXPECT_EQ(cyphertext_this, cyphertext_other);
+  EXPECT_EQ(ciphertext_this, ciphertext_other);
 }
 
 // Tests that the result of AesWithHkdf Decrypt is the same as the result
@@ -65,15 +66,15 @@ TEST(AesWithHkdfTest, compareDecrypt) {
   std::string_view plaintext = "Some data to encrypt.";
   ASSERT_OK_AND_ASSIGN(SecretData result,
                        hkdf->ComputeHkdf(key, aes->key_size_bytes()));
-  ASSERT_OK_AND_ASSIGN(std::string cyphertext_other,
+  ASSERT_OK_AND_ASSIGN(std::string ciphertext_other,
                        aes->Encrypt(plaintext, result));
   ASSERT_OK_AND_ASSIGN(std::string decrypted_other,
-                       aes->Decrypt(cyphertext_other, result));
+                       aes->Decrypt(ciphertext_other, result));
   AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
-  ASSERT_OK_AND_ASSIGN(std::string cyphertext_this,
+  ASSERT_OK_AND_ASSIGN(std::string ciphertext_this,
                        aes_hkdf.Encrypt(plaintext, key));
   ASSERT_OK_AND_ASSIGN(std::string decrypted_this,
-                       aes_hkdf.Decrypt(cyphertext_this, key));
+                       aes_hkdf.Decrypt(ciphertext_this, key));
   EXPECT_EQ(decrypted_this, decrypted_other);
 }
 
@@ -84,7 +85,7 @@ TEST(AesWithHkdfTest, emptyKeyEncrypt) {
   AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
   auto result = aes_hkdf.Encrypt("input", SecretDataFromStringView(""));
   EXPECT_THAT(result.status(),
-              StatusIs(absl::StatusCode::kInvalidArgument, ""));
+              wfa::StatusIs(absl::StatusCode::kInvalidArgument, ""));
 }
 
 // Test with empty key and proper input - Decrypt
@@ -94,10 +95,11 @@ TEST(AesWithHkdfTest, emptyKeyDecrypt) {
   AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
   auto result = aes_hkdf.Decrypt("input", SecretDataFromStringView(""));
   EXPECT_THAT(result.status(),
-              StatusIs(absl::StatusCode::kInvalidArgument, ""));
+              wfa::StatusIs(absl::StatusCode::kInvalidArgument, ""));
 }
 
-// Tests that different keys with the same string return different values
+// Tests that different keys with the same string return different values for
+// Encrypt
 TEST(AesTest, differentKeySameStringEncrypt) {
   std::unique_ptr<Hkdf> hkdf = GetSha256Hkdf();
   std::unique_ptr<Aes> aes = GetAesSivCmac512();
@@ -105,11 +107,11 @@ TEST(AesTest, differentKeySameStringEncrypt) {
   SecretData key_2 = SecretDataFromStringView("key2");
   std::string_view plaintext = "Some data to encrypt.";
   AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
-  ASSERT_OK_AND_ASSIGN(std::string cyphertext_1,
+  ASSERT_OK_AND_ASSIGN(std::string ciphertext_1,
                        aes_hkdf.Encrypt(plaintext, key_1));
-  ASSERT_OK_AND_ASSIGN(std::string cyphertext_2,
+  ASSERT_OK_AND_ASSIGN(std::string ciphertext_2,
                        aes_hkdf.Encrypt(plaintext, key_2));
-  EXPECT_NE(cyphertext_1, cyphertext_2);
+  EXPECT_NE(ciphertext_1, ciphertext_2);
 }
 
 // Tests that decrypting with a different key than encryption gives an error
@@ -120,14 +122,15 @@ TEST(AesTest, differentKeyDecrypt) {
   SecretData key_2 = SecretDataFromStringView("key2");
   std::string_view plaintext = "Some data to encrypt.";
   AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
-  ASSERT_OK_AND_ASSIGN(std::string cyphertext,
+  ASSERT_OK_AND_ASSIGN(std::string ciphertext,
                        aes_hkdf.Encrypt(plaintext, key_1));
-  auto decrypted = aes_hkdf.Decrypt(cyphertext, key_2);
+  auto decrypted = aes_hkdf.Decrypt(ciphertext, key_2);
   EXPECT_THAT(decrypted.status(),
-              StatusIs(absl::StatusCode::kInvalidArgument, ""));
+              wfa::StatusIs(absl::StatusCode::kInvalidArgument, ""));
 }
 
-// Tests that the same key with different strings return different values
+// Tests that the same key with different strings return different values for
+// Encrypt
 TEST(AesTest, sameKeyDifferentStringEncrypt) {
   std::unique_ptr<Hkdf> hkdf = GetSha256Hkdf();
   std::unique_ptr<Aes> aes = GetAesSivCmac512();
@@ -135,14 +138,15 @@ TEST(AesTest, sameKeyDifferentStringEncrypt) {
   std::string_view plaintext_1 = "Some data to encrypt.";
   std::string_view plaintext_2 = "Additional data to encrypt.";
   AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
-  ASSERT_OK_AND_ASSIGN(std::string cyphertext_1,
+  ASSERT_OK_AND_ASSIGN(std::string ciphertext_1,
                        aes_hkdf.Encrypt(plaintext_1, key));
-  ASSERT_OK_AND_ASSIGN(std::string cyphertext_2,
+  ASSERT_OK_AND_ASSIGN(std::string ciphertext_2,
                        aes_hkdf.Encrypt(plaintext_2, key));
-  EXPECT_NE(cyphertext_1, cyphertext_2);
+  EXPECT_NE(ciphertext_1, ciphertext_2);
 }
 
-// Tests that the same key with different strings return different values
+// Tests that the same key with different strings return different values for
+// Decrypt
 TEST(AesTest, sameKeyDifferentStringDecrypt) {
   std::unique_ptr<Hkdf> hkdf = GetSha256Hkdf();
   std::unique_ptr<Aes> aes = GetAesSivCmac512();
@@ -150,14 +154,14 @@ TEST(AesTest, sameKeyDifferentStringDecrypt) {
   std::string_view plaintext_1 = "Some data to encrypt.";
   std::string_view plaintext_2 = "Additional data to encrypt.";
   AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
-  ASSERT_OK_AND_ASSIGN(std::string cyphertext_1,
+  ASSERT_OK_AND_ASSIGN(std::string ciphertext_1,
                        aes_hkdf.Encrypt(plaintext_1, key));
-  ASSERT_OK_AND_ASSIGN(std::string cyphertext_2,
+  ASSERT_OK_AND_ASSIGN(std::string ciphertext_2,
                        aes_hkdf.Encrypt(plaintext_2, key));
   ASSERT_OK_AND_ASSIGN(std::string decrypted_1,
-                       aes_hkdf.Decrypt(cyphertext_1, key));
+                       aes_hkdf.Decrypt(ciphertext_1, key));
   ASSERT_OK_AND_ASSIGN(std::string decrypted_2,
-                       aes_hkdf.Decrypt(cyphertext_2, key));
+                       aes_hkdf.Decrypt(ciphertext_2, key));
   EXPECT_NE(decrypted_1, decrypted_2);
 }
 

--- a/src/test/cc/wfanet/panelmatch/common/crypto/aes_with_hkdf_test.cc
+++ b/src/test/cc/wfanet/panelmatch/common/crypto/aes_with_hkdf_test.cc
@@ -15,10 +15,9 @@
 #include "wfanet/panelmatch/common/crypto/aes_with_hkdf.h"
 
 #include "absl/strings/escaping.h"
+#include "common_cpp/testing/status_macros.h"
+#include "common_cpp/testing/status_matchers.h"
 #include "gtest/gtest.h"
-//#include "src/test/cc/testutil/matchers.h"
-#include "src/main/cc/common_cpp/testing/status_macros.h"
-#include "src/main/cc/common_cpp/testing/status_matchers.h"
 
 namespace wfanet::panelmatch::common::crypto {
 namespace {
@@ -105,6 +104,7 @@ TEST(AesTest, differentKeySameStringEncrypt) {
   std::unique_ptr<Aes> aes = GetAesSivCmac512();
   SecretData key_1 = SecretDataFromStringView("key1");
   SecretData key_2 = SecretDataFromStringView("key2");
+  ASSERT_NE(key_1, key_2);
   std::string_view plaintext = "Some data to encrypt.";
   AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
   ASSERT_OK_AND_ASSIGN(std::string ciphertext_1,
@@ -120,6 +120,7 @@ TEST(AesTest, differentKeyDecrypt) {
   std::unique_ptr<Aes> aes = GetAesSivCmac512();
   SecretData key_1 = SecretDataFromStringView("key1");
   SecretData key_2 = SecretDataFromStringView("key2");
+  ASSERT_NE(key_1, key_2);
   std::string_view plaintext = "Some data to encrypt.";
   AesWithHkdf aes_hkdf(std::move(hkdf), std::move(aes));
   ASSERT_OK_AND_ASSIGN(std::string ciphertext,


### PR DESCRIPTION
Add the Aes_Siv_BoringSsl implementation to Aes along with tests for Aes
and AesWithHkdf

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/47)
<!-- Reviewable:end -->
