### PR TITLE
Update task execution to lazily stream inputs and outputs

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTask.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTask.kt
@@ -15,6 +15,8 @@
 package org.wfanet.panelmatch.client.exchangetasks
 
 import com.google.protobuf.ByteString
+import kotlinx.coroutines.flow.Flow
+import org.wfanet.measurement.storage.StorageClient.Blob
 
 /** Interface for ExchangeTask. */
 interface ExchangeTask {
@@ -24,5 +26,5 @@ interface ExchangeTask {
    * @param input inputs specified by [task].
    * @return Executed output. It is a map from the labels to the payload associated with the label.
    */
-  suspend fun execute(input: Map<String, ByteString>): Map<String, ByteString>
+  suspend fun execute(input: Map<String, Blob>): Map<String, Flow<ByteString>>
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/InputTask.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/InputTask.kt
@@ -15,8 +15,10 @@
 package org.wfanet.panelmatch.client.exchangetasks
 
 import com.google.protobuf.ByteString
+import kotlinx.coroutines.flow.Flow
 import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow
 import org.wfanet.measurement.common.throttler.Throttler
+import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.panelmatch.client.storage.Storage
 import org.wfanet.panelmatch.client.storage.Storage.NotFoundException
 
@@ -59,7 +61,9 @@ class InputTask(
     }
   }
 
-  override suspend fun execute(input: Map<String, ByteString>): Map<String, ByteString> {
+  override suspend fun execute(
+    input: Map<String, StorageClient.Blob>
+  ): Map<String, Flow<ByteString>> {
     while (true) {
       if (throttler.onReady { isReady() }) {
         // This function only returns that input is ready. It does not return actual values.

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/FileSystemStorage.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/FileSystemStorage.kt
@@ -17,6 +17,7 @@ package org.wfanet.panelmatch.client.storage
 import com.google.protobuf.ByteString
 import java.io.File
 import kotlinx.coroutines.flow.Flow
+import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
 import org.wfanet.panelmatch.client.logger.loggerFor
 
@@ -39,10 +40,9 @@ class FileSystemStorage(baseDir: String) : Storage {
     storageClient = FileSystemStorageClient(directory = baseFolder)
   }
 
-  override suspend fun read(path: String): Flow<ByteString> {
+  override suspend fun read(path: String): StorageClient.Blob {
     logger.fine("Read:${path}\n")
-    val blob = storageClient.getBlob(path) ?: throw Storage.NotFoundException(path)
-    return blob.read(4096)
+    return storageClient.getBlob(path) ?: throw Storage.NotFoundException(path)
   }
 
   override suspend fun write(path: String, data: Flow<ByteString>) {

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/InMemoryStorage.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/InMemoryStorage.kt
@@ -15,33 +15,22 @@
 package org.wfanet.panelmatch.client.storage
 
 import com.google.protobuf.ByteString
-import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.fold
-import org.wfanet.measurement.common.asBufferedFlow
+import org.wfanet.measurement.storage.StorageClient
 
 /**
  * Stores everything in memory. Nothing is persistent. Use with caution. Uses a simple hashmap to
  * storage everything where path is the key.
  */
 class InMemoryStorage(private val keyPrefix: String) : Storage {
-  private var inMemoryStorage = ConcurrentHashMap<String, ByteString>()
 
-  private fun getKey(path: String): String {
-    return "$keyPrefix$path"
-  }
+  private val storageClient = InMemoryStorageClient(keyPrefix = keyPrefix)
 
-  override suspend fun read(path: String): Flow<ByteString> {
-    val key = getKey(path)
-    return inMemoryStorage
-      .getOrElse(key) { throw Storage.NotFoundException(key) }
-      .asBufferedFlow(4096)
+  override suspend fun read(path: String): StorageClient.Blob {
+    return requireNotNull(storageClient.getBlob(path))
   }
 
   override suspend fun write(path: String, data: Flow<ByteString>) {
-    val key = getKey(path)
-
-    require(!inMemoryStorage.containsKey(key)) { "Cannot write to an existing key: $key" }
-    inMemoryStorage[key] = data.fold(ByteString.EMPTY, { agg, chunk -> agg.concat(chunk) })
+    storageClient.createBlob(path, data)
   }
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/InMemoryStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/InMemoryStorageClient.kt
@@ -1,0 +1,78 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.storage
+
+import com.google.protobuf.ByteString
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.fold
+import org.wfanet.measurement.common.BYTES_PER_MIB
+import org.wfanet.measurement.common.asBufferedFlow
+import org.wfanet.measurement.storage.StorageClient
+
+/**
+ * The default byte buffer size. Chosen as it is a commonly used default buffer size in an attempt
+ * to keep the tests as close to actual usage as possible.
+ */
+private const val BYTE_BUFFER_SIZE = BYTES_PER_MIB * 1
+
+/** [StorageClient] for InMemoryStorage service. */
+class InMemoryStorageClient(private val keyPrefix: String) : StorageClient {
+
+  private var inMemoryStorageMap = ConcurrentHashMap<String, StorageClient.Blob>()
+
+  private fun getKey(path: String): String {
+    return "$keyPrefix$path"
+  }
+
+  private fun deleteKey(path: String) {
+    inMemoryStorageMap.remove(getKey(path))
+  }
+
+  override val defaultBufferSizeBytes: Int
+    get() = BYTE_BUFFER_SIZE
+
+  override suspend fun createBlob(blobKey: String, content: Flow<ByteString>): StorageClient.Blob {
+    val mapKey: String = getKey(blobKey)
+    require(!inMemoryStorageMap.containsKey(mapKey)) { "Cannot write to an existing key: $blobKey" }
+
+    // As we're using this primarily for unit tests, we want to collect the input to record
+    // size and to emulate "writing out" to memory.
+    val newBlob = Blob(content.fold(ByteString.EMPTY, { agg, chunk -> agg.concat(chunk) }), blobKey)
+    inMemoryStorageMap[mapKey] = newBlob
+
+    return newBlob
+  }
+
+  override fun getBlob(blobKey: String): StorageClient.Blob? {
+    val mapKey: String = getKey(blobKey)
+    require(inMemoryStorageMap.containsKey(mapKey)) { "Cannot find key: $blobKey" }
+
+    return inMemoryStorageMap[mapKey]
+  }
+
+  private inner class Blob(private val byteData: ByteString, private val blobKey: String) :
+    StorageClient.Blob {
+
+    override val size: Long = byteData.size().toLong()
+
+    override val storageClient: InMemoryStorageClient = this@InMemoryStorageClient
+
+    override fun read(bufferSizeBytes: Int): Flow<ByteString> =
+      byteData.asBufferedFlow(bufferSizeBytes)
+
+    override fun delete() = storageClient.deleteKey(blobKey)
+  }
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/testing/AbstractStorageTest.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/testing/AbstractStorageTest.kt
@@ -34,7 +34,7 @@ abstract class AbstractStorageTest {
   @Test
   fun `write and read FileSystemStorage`() = runBlockingTest {
     privateStorage.write(KEY, VALUE.asBufferedFlow(1024))
-    assertThat(privateStorage.read(KEY).reduce { a, b -> a.concat(b) }).isEqualTo(VALUE)
+    assertThat(privateStorage.read(KEY).read(1024).reduce { a, b -> a.concat(b) }).isEqualTo(VALUE)
   }
 
   @Test
@@ -53,14 +53,14 @@ abstract class AbstractStorageTest {
   @Test
   fun `shared storage cannot read from private storage`() = runBlockingTest {
     privateStorage.write(KEY, VALUE.asBufferedFlow(1024))
-    privateStorage.read(KEY).reduce { a, b -> a.concat(b) } // Does not throw.
+    privateStorage.read(KEY).read(1024).reduce { a, b -> a.concat(b) } // Does not throw.
     assertFailsWith<NotFoundException> { sharedStorage.read(KEY) }
   }
 
   @Test
   fun `private storage cannot read from shared storage`() = runBlockingTest {
     sharedStorage.write(KEY, VALUE.asBufferedFlow(1024))
-    sharedStorage.read(KEY).reduce { a, b -> a.concat(b) } // Does not throw.
+    sharedStorage.read(KEY).read(1024).reduce { a, b -> a.concat(b) } // Does not throw.
     assertFailsWith<NotFoundException> { privateStorage.read(KEY) }
   }
 

--- a/src/main/kotlin/org/wfanet/panelmatch/protocol/common/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/protocol/common/BUILD.bazel
@@ -11,5 +11,6 @@ kt_jvm_library(
         "//src/main/proto/wfa/panelmatch/protocol/exchangesteps:exchangesteps_java_proto",
         "//src/main/swig/wfanet/panelmatch/protocol/crypto:deterministic_commutative_encryption_utility",
         "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common",
     ],
 )

--- a/src/main/kotlin/org/wfanet/panelmatch/protocol/common/SharedInputs.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/protocol/common/SharedInputs.kt
@@ -15,11 +15,21 @@
 package org.wfanet.panelmatch.protocol.common
 
 import com.google.protobuf.ByteString
+import kotlinx.coroutines.flow.Flow
+import org.wfanet.measurement.common.asBufferedFlow
 import org.wfanet.panelmatch.protocol.SharedInputs
 
 /** Insert [data] into a [SharedInputs] proto and then serializes it. */
 fun makeSerializedSharedInputs(data: List<ByteString>): ByteString {
   return SharedInputs.newBuilder().addAllData(data).build().toByteString()
+}
+
+/**
+ * Converts the [ByteString] [List] into a [Flow] to allow for asynchronous operations on the
+ * elements downstream.
+ */
+fun makeSerializedSharedInputFlow(data: List<ByteString>, bufferSize: Int): Flow<ByteString> {
+  return makeSerializedSharedInputs(data).asBufferedFlow(bufferSize)
 }
 
 /** Deserializes [data] as a [SharedInputs] proto and returns its `data` field. */

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/DeterministicCommutativeCryptorExchangeTaskTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/DeterministicCommutativeCryptorExchangeTaskTest.kt
@@ -20,27 +20,32 @@ import kotlin.test.assertFailsWith
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyZeroInteractions
 import org.mockito.kotlin.whenever
+import org.wfanet.measurement.common.asBufferedFlow
 import org.wfanet.panelmatch.client.launcher.testing.DOUBLE_BLINDED_KEYS
 import org.wfanet.panelmatch.client.launcher.testing.JOIN_KEYS
 import org.wfanet.panelmatch.client.launcher.testing.LOOKUP_KEYS
 import org.wfanet.panelmatch.client.launcher.testing.MP_0_SECRET_KEY
 import org.wfanet.panelmatch.client.launcher.testing.SINGLE_BLINDED_KEYS
 import org.wfanet.panelmatch.client.launcher.testing.buildMockCryptor
+import org.wfanet.panelmatch.client.storage.InMemoryStorageClient
+import org.wfanet.panelmatch.protocol.common.makeSerializedSharedInputFlow
 import org.wfanet.panelmatch.protocol.common.makeSerializedSharedInputs
 
 private val MP_0_SECRET_KEY = ByteString.copyFromUtf8("some-key")
 
 @RunWith(JUnit4::class)
 class DeterministicCommutativeCryptorExchangeTaskTest {
+  private val mockStorage = InMemoryStorageClient(keyPrefix = "mock")
   val deterministicCommutativeCryptor = buildMockCryptor()
+
   val ATTEMPT_KEY = java.util.UUID.randomUUID().toString()
 
   @Test
@@ -51,10 +56,22 @@ class DeterministicCommutativeCryptorExchangeTaskTest {
             CryptorExchangeTask.forDecryption(deterministicCommutativeCryptor)
               .execute(
                 mapOf(
-                  "encryption-key" to MP_0_SECRET_KEY,
-                  "encrypted-data" to makeSerializedSharedInputs(DOUBLE_BLINDED_KEYS)
+                  "encryption-key" to
+                    mockStorage.createBlob(
+                      "encryption-key",
+                      MP_0_SECRET_KEY.asBufferedFlow(mockStorage.defaultBufferSizeBytes)
+                    ),
+                  "encrypted-data" to
+                    mockStorage.createBlob(
+                      "encrypted-data",
+                      makeSerializedSharedInputFlow(
+                        DOUBLE_BLINDED_KEYS,
+                        mockStorage.defaultBufferSizeBytes
+                      )
+                    )
                 )
               )
+              .mapValues { it.value.fold(ByteString.EMPTY, { agg, chunk -> agg.concat(chunk) }) }
           assertThat(result)
             .containsExactly("decrypted-data", makeSerializedSharedInputs(LOOKUP_KEYS))
         }
@@ -73,8 +90,19 @@ class DeterministicCommutativeCryptorExchangeTaskTest {
               CryptorExchangeTask.forDecryption(deterministicCommutativeCryptor)
                 .execute(
                   mapOf(
-                    "encryption-key" to MP_0_SECRET_KEY,
-                    "encrypted-data" to makeSerializedSharedInputs(SINGLE_BLINDED_KEYS)
+                    "encryption-key" to
+                      mockStorage.createBlob(
+                        "encryption-key",
+                        MP_0_SECRET_KEY.asBufferedFlow(mockStorage.defaultBufferSizeBytes)
+                      ),
+                    "encrypted-data" to
+                      mockStorage.createBlob(
+                        "encrypted-data",
+                        makeSerializedSharedInputFlow(
+                          SINGLE_BLINDED_KEYS,
+                          mockStorage.defaultBufferSizeBytes
+                        )
+                      )
                   )
                 )
             }
@@ -89,11 +117,30 @@ class DeterministicCommutativeCryptorExchangeTaskTest {
       async(CoroutineName(ATTEMPT_KEY) + Dispatchers.Default) {
           assertFailsWith(IllegalArgumentException::class) {
             CryptorExchangeTask.forDecryption(deterministicCommutativeCryptor)
-              .execute(mapOf("encrypted-data" to makeSerializedSharedInputs(SINGLE_BLINDED_KEYS)))
+              .execute(
+                mapOf(
+                  "encrypted-data" to
+                    mockStorage.createBlob(
+                      "encrypted-data",
+                      makeSerializedSharedInputFlow(
+                        SINGLE_BLINDED_KEYS,
+                        mockStorage.defaultBufferSizeBytes
+                      )
+                    )
+                )
+              )
           }
           assertFailsWith(IllegalArgumentException::class) {
             CryptorExchangeTask.forDecryption(deterministicCommutativeCryptor)
-              .execute(mapOf("encryption-key" to MP_0_SECRET_KEY))
+              .execute(
+                mapOf(
+                  "encryption-key" to
+                    mockStorage.createBlob(
+                      "encryption-key",
+                      MP_0_SECRET_KEY.asBufferedFlow(mockStorage.defaultBufferSizeBytes)
+                    )
+                )
+              )
           }
           verifyZeroInteractions(deterministicCommutativeCryptor)
         }
@@ -108,10 +155,19 @@ class DeterministicCommutativeCryptorExchangeTaskTest {
             CryptorExchangeTask.forEncryption(deterministicCommutativeCryptor)
               .execute(
                 mapOf(
-                  "encryption-key" to MP_0_SECRET_KEY,
-                  "unencrypted-data" to makeSerializedSharedInputs(JOIN_KEYS)
+                  "encryption-key" to
+                    mockStorage.createBlob(
+                      "encryption-key",
+                      MP_0_SECRET_KEY.asBufferedFlow(mockStorage.defaultBufferSizeBytes)
+                    ),
+                  "unencrypted-data" to
+                    mockStorage.createBlob(
+                      "unencrypted-data",
+                      makeSerializedSharedInputFlow(JOIN_KEYS, mockStorage.defaultBufferSizeBytes)
+                    )
                 )
               )
+              .mapValues { it.value.fold(ByteString.EMPTY, { agg, chunk -> agg.concat(chunk) }) }
           assertThat(result)
             .containsExactly("encrypted-data", makeSerializedSharedInputs(SINGLE_BLINDED_KEYS))
         }
@@ -130,8 +186,16 @@ class DeterministicCommutativeCryptorExchangeTaskTest {
               CryptorExchangeTask.forEncryption(deterministicCommutativeCryptor)
                 .execute(
                   mapOf(
-                    "encryption-key" to MP_0_SECRET_KEY,
-                    "unencrypted-data" to makeSerializedSharedInputs(JOIN_KEYS)
+                    "encryption-key" to
+                      mockStorage.createBlob(
+                        "encryption-key",
+                        MP_0_SECRET_KEY.asBufferedFlow(mockStorage.defaultBufferSizeBytes)
+                      ),
+                    "unencrypted-data" to
+                      mockStorage.createBlob(
+                        "unencrypted-data",
+                        makeSerializedSharedInputFlow(JOIN_KEYS, mockStorage.defaultBufferSizeBytes)
+                      )
                   )
                 )
             }
@@ -147,11 +211,27 @@ class DeterministicCommutativeCryptorExchangeTaskTest {
         async(CoroutineName(ATTEMPT_KEY) + Dispatchers.Default) {
           assertFailsWith(IllegalArgumentException::class) {
             CryptorExchangeTask.forEncryption(deterministicCommutativeCryptor)
-              .execute(mapOf("unencrypted-data" to makeSerializedSharedInputs(JOIN_KEYS)))
+              .execute(
+                mapOf(
+                  "unencrypted-data" to
+                    mockStorage.createBlob(
+                      "unencrypted-data",
+                      makeSerializedSharedInputFlow(JOIN_KEYS, mockStorage.defaultBufferSizeBytes)
+                    )
+                )
+              )
           }
           assertFailsWith(IllegalArgumentException::class) {
             CryptorExchangeTask.forEncryption(deterministicCommutativeCryptor)
-              .execute(mapOf("encryption-key" to MP_0_SECRET_KEY))
+              .execute(
+                mapOf(
+                  "encryption-key" to
+                    mockStorage.createBlob(
+                      "encryption-key",
+                      MP_0_SECRET_KEY.asBufferedFlow(mockStorage.defaultBufferSizeBytes)
+                    )
+                )
+              )
           }
           verifyZeroInteractions(deterministicCommutativeCryptor)
         }
@@ -169,10 +249,22 @@ class DeterministicCommutativeCryptorExchangeTaskTest {
             CryptorExchangeTask.forReEncryption(deterministicCommutativeCryptor)
               .execute(
                 mapOf(
-                  "encryption-key" to MP_0_SECRET_KEY,
-                  "encrypted-data" to makeSerializedSharedInputs(SINGLE_BLINDED_KEYS)
+                  "encryption-key" to
+                    mockStorage.createBlob(
+                      "encryption-key",
+                      MP_0_SECRET_KEY.asBufferedFlow(mockStorage.defaultBufferSizeBytes)
+                    ),
+                  "encrypted-data" to
+                    mockStorage.createBlob(
+                      "encrypted-data",
+                      makeSerializedSharedInputFlow(
+                        SINGLE_BLINDED_KEYS,
+                        mockStorage.defaultBufferSizeBytes
+                      )
+                    )
                 )
               )
+              .mapValues { it.value.fold(ByteString.EMPTY, { agg, chunk -> agg.concat(chunk) }) }
           assertThat(result)
             .containsExactly("reencrypted-data", makeSerializedSharedInputs(DOUBLE_BLINDED_KEYS))
         }
@@ -191,8 +283,19 @@ class DeterministicCommutativeCryptorExchangeTaskTest {
               CryptorExchangeTask.forReEncryption(deterministicCommutativeCryptor)
                 .execute(
                   mapOf(
-                    "encryption-key" to MP_0_SECRET_KEY,
-                    "encrypted-data" to makeSerializedSharedInputs(SINGLE_BLINDED_KEYS)
+                    "encryption-key" to
+                      mockStorage.createBlob(
+                        "encryption-key",
+                        MP_0_SECRET_KEY.asBufferedFlow(mockStorage.defaultBufferSizeBytes)
+                      ),
+                    "encrypted-data" to
+                      mockStorage.createBlob(
+                        "encrypted-data",
+                        makeSerializedSharedInputFlow(
+                          SINGLE_BLINDED_KEYS,
+                          mockStorage.defaultBufferSizeBytes
+                        )
+                      )
                   )
                 )
             }
@@ -207,11 +310,30 @@ class DeterministicCommutativeCryptorExchangeTaskTest {
       async(CoroutineName(ATTEMPT_KEY) + Dispatchers.Default) {
           assertFailsWith(IllegalArgumentException::class) {
             CryptorExchangeTask.forReEncryption(deterministicCommutativeCryptor)
-              .execute(mapOf("encrypted-data" to makeSerializedSharedInputs(SINGLE_BLINDED_KEYS)))
+              .execute(
+                mapOf(
+                  "encrypted-data" to
+                    mockStorage.createBlob(
+                      "encrypted-data",
+                      makeSerializedSharedInputFlow(
+                        SINGLE_BLINDED_KEYS,
+                        mockStorage.defaultBufferSizeBytes
+                      )
+                    )
+                )
+              )
           }
           assertFailsWith(IllegalArgumentException::class) {
             CryptorExchangeTask.forReEncryption(deterministicCommutativeCryptor)
-              .execute(mapOf("encryption-key" to MP_0_SECRET_KEY))
+              .execute(
+                mapOf(
+                  "encryption-key" to
+                    mockStorage.createBlob(
+                      "encryption-key",
+                      MP_0_SECRET_KEY.asBufferedFlow(mockStorage.defaultBufferSizeBytes)
+                    )
+                )
+              )
           }
           verifyZeroInteractions(deterministicCommutativeCryptor)
         }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutorImplTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutorImplTest.kt
@@ -19,16 +19,22 @@ import com.google.protobuf.ByteString
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.fold
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.mock
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
 import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow.Step.StepCase.ENCRYPT_STEP
+import org.wfanet.measurement.common.asBufferedFlow
+import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.panelmatch.client.exchangetasks.ExchangeTask
 import org.wfanet.panelmatch.client.launcher.testing.FakeTimeout
 import org.wfanet.panelmatch.client.launcher.testing.buildStep
 import org.wfanet.panelmatch.client.storage.InMemoryStorage
+import org.wfanet.panelmatch.client.storage.toByteString
 import org.wfanet.panelmatch.common.testing.runBlockingTest
 
 @RunWith(JUnit4::class)
@@ -41,12 +47,17 @@ class ExchangeTaskExecutorImplTest {
 
   private val exchangeTask =
     object : ExchangeTask {
-      override suspend fun execute(input: Map<String, ByteString>): Map<String, ByteString> {
-        val result =
-          input.mapKeys { "Out:${it.key}" }.mapValues {
-            ByteString.copyFromUtf8("Out:${it.value.toStringUtf8()}")
-          }
-        return result
+      override suspend fun execute(
+        input: Map<String, StorageClient.Blob>
+      ): Map<String, Flow<ByteString>> {
+        return input.mapKeys { "Out:${it.key}" }.mapValues {
+          val valString: String =
+            it.value
+              .read(1024)
+              .fold(ByteString.EMPTY, { agg, chunk -> agg.concat(chunk) })
+              .toStringUtf8()
+          ByteString.copyFromUtf8("Out:$valString").asBufferedFlow(1024)
+        }
       }
     }
 
@@ -58,8 +69,14 @@ class ExchangeTaskExecutorImplTest {
     val blob1 = ByteString.copyFromUtf8("blob1")
     val blob2 = ByteString.copyFromUtf8("blob2")
 
-    privateStorage.batchWrite(outputLabels = mapOf("a" to "b"), data = mapOf("a" to blob1))
-    sharedStorage.batchWrite(outputLabels = mapOf("c" to "d"), data = mapOf("c" to blob2))
+    privateStorage.batchWrite(
+      outputLabels = mapOf("a" to "b"),
+      data = mapOf("a" to blob1.asBufferedFlow(1024))
+    )
+    sharedStorage.batchWrite(
+      outputLabels = mapOf("c" to "d"),
+      data = mapOf("c" to blob2.asBufferedFlow(1024))
+    )
 
     exchangeTaskExecutor.execute(
       ExchangeStepAttemptKey("w", "x", "y", "z"),
@@ -72,10 +89,12 @@ class ExchangeTaskExecutorImplTest {
       )
     )
 
-    assertThat(privateStorage.batchRead(mapOf("Out:c" to "e")))
+    assertThat(
+        privateStorage.batchRead(mapOf("Out:c" to "e")).mapValues { it.value.toByteString() }
+      )
       .containsExactly("Out:c", ByteString.copyFromUtf8("Out:blob2"))
 
-    assertThat(sharedStorage.batchRead(mapOf("Out:a" to "f")))
+    assertThat(sharedStorage.batchRead(mapOf("Out:a" to "f")).mapValues { it.value.toByteString() })
       .containsExactly("Out:a", ByteString.copyFromUtf8("Out:blob1"))
   }
 
@@ -85,7 +104,7 @@ class ExchangeTaskExecutorImplTest {
 
     privateStorage.batchWrite(
       outputLabels = mapOf("a" to "b"),
-      data = mapOf("a" to ByteString.EMPTY)
+      data = mapOf("a" to emptyFlow<ByteString>())
     )
 
     assertFailsWith<CancellationException> {


### PR DESCRIPTION
Uses StorageClient.Blob more directly and adds a method to convert blob
data to bytestring.

Implements an InMemoryStorageClient to make it possible to test.

The goal is to avoid reading in the entirety of an input (or collecting
an entire output before writing) all at once to avoid memory issues.
While the existing exchange task steps can and do collect their inputs,
these will be revisited in a later PR and other tasks with larger inputs
and outputs will leverage these streams.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/75)
<!-- Reviewable:end -->
