### PR TITLE
Add support for GCS storage in panel exchange

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/testing/AbstractStorageTest.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/testing/AbstractStorageTest.kt
@@ -22,6 +22,7 @@ import org.junit.Test
 import org.wfanet.measurement.common.asBufferedFlow
 import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.panelmatch.client.storage.StorageNotFoundException
+import org.wfanet.panelmatch.client.storage.verifiedBatchWrite
 import org.wfanet.panelmatch.client.storage.verifiedRead
 import org.wfanet.panelmatch.client.storage.verifiedWrite
 import org.wfanet.panelmatch.common.testing.runBlockingTest
@@ -34,22 +35,24 @@ abstract class AbstractStorageTest {
   abstract val sharedStorage: StorageClient
 
   @Test
-  fun `write and read FileSystemStorage`() = runBlockingTest {
+  fun `write and read Storage`() = runBlockingTest {
     privateStorage.verifiedWrite(KEY, VALUE.asBufferedFlow(1024))
     assertThat(privateStorage.verifiedRead(KEY).read(1024).reduce { a, b -> a.concat(b) })
       .isEqualTo(VALUE)
   }
 
   @Test
-  fun `get error for invalid key from FileSystemStorage`() = runBlockingTest {
+  fun `get error for invalid key from Storage`() = runBlockingTest {
     assertFailsWith<StorageNotFoundException> { privateStorage.verifiedRead(KEY) }
   }
 
   @Test
-  fun `get error for rewriting to same key 2x in FileSystemStorage`() = runBlockingTest {
-    privateStorage.verifiedWrite(KEY, VALUE.asBufferedFlow(1024))
+  fun `get error for rewriting to same key 2x in Storage`() = runBlockingTest {
     assertFailsWith<IllegalArgumentException> {
-      privateStorage.verifiedWrite(KEY, VALUE.asBufferedFlow(1024))
+      privateStorage.verifiedBatchWrite(
+        mapOf("a" to KEY, "b" to KEY),
+        mapOf(KEY to VALUE.asBufferedFlow(1024))
+      )
     }
   }
 

--- a/src/test/kotlin/org/wfanet/panelmatch/client/storage/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/storage/BUILD.bazel
@@ -33,3 +33,22 @@ kt_jvm_test(
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
     ],
 )
+
+kt_jvm_test(
+    name = "GcsStorageTest",
+    srcs = ["GcsStorageTest.kt"],
+    test_class = "org.wfanet.panelmatch.client.storage.GcsStorageTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/panelmatch/client/storage",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/storage/testing",
+        "//src/main/proto/wfa/panelmatch/protocol/exchangesteps:exchangesteps_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/cloud/storage/contrib/nio",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/common/truth/extensions/proto",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+        "@wfa_common_jvm//imports/kotlin/org/mockito/kotlin",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc/testing",
+        "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/gcloud/gcs",
+    ],
+)

--- a/src/test/kotlin/org/wfanet/panelmatch/client/storage/GcsStorageTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/storage/GcsStorageTest.kt
@@ -1,0 +1,35 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.storage
+
+import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
+import org.wfanet.measurement.gcloud.gcs.GcsStorageClient
+import org.wfanet.panelmatch.client.storage.testing.AbstractStorageTest
+
+class GcsStorageTest : AbstractStorageTest() {
+
+  override val privateStorage by lazy {
+    GcsStorageClient(LocalStorageHelper.getOptions().service, PRIVATE_BUCKET)
+  }
+
+  override val sharedStorage by lazy {
+    GcsStorageClient(LocalStorageHelper.getOptions().service, SHARED_BUCKET)
+  }
+
+  companion object {
+    private const val PRIVATE_BUCKET = "private-test-bucket"
+    private const val SHARED_BUCKET = "shared-test-bucket"
+  }
+}


### PR DESCRIPTION
Currently only adds unit tests using the GcsStorageClient as the backing
storage.

Small PR before adding signing/verification support.

Will add more support for building a GCS (and all other types of) storage client in/around CoroutineLauncher in a followup PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/95)
<!-- Reviewable:end -->
