### PR TITLE
Support registering KeyLoaders

### DIFF
--- a/src/main/cc/wfa/panelmatch/client/eventpreprocessing/BUILD.bazel
+++ b/src/main/cc/wfa/panelmatch/client/eventpreprocessing/BUILD.bazel
@@ -12,6 +12,7 @@ cc_library(
         "//src/main/cc/wfa/panelmatch/common/crypto:aes_with_hkdf",
         "//src/main/cc/wfa/panelmatch/common/crypto:deterministic_commutative_cipher",
         "//src/main/cc/wfa/panelmatch/common/crypto:hkdf",
+        "//src/main/cc/wfa/panelmatch/common/crypto:key_loader",
         "//src/main/cc/wfa/panelmatch/protocol/crypto:event_data_preprocessor",
         "//src/main/proto/wfa/panelmatch/client/eventpreprocessing:preprocess_events_cc_proto",
         "@com_google_absl//absl/algorithm:container",

--- a/src/main/cc/wfa/panelmatch/common/crypto/BUILD.bazel
+++ b/src/main/cc/wfa/panelmatch/common/crypto/BUILD.bazel
@@ -106,3 +106,40 @@ cc_library(
         "@tink_base//cc/util:secret_data",
     ],
 )
+
+cc_library(
+    name = "key_loader",
+    srcs = ["key_loader.cc"],
+    hdrs = ["key_loader.h"],
+    strip_include_prefix = _INCLUDE_PREFIX,
+    deps = [
+        "@com_github_google_glog//:glog",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/synchronization",
+        "@tink_base//cc/util:secret_data",
+    ],
+)
+
+cc_library(
+    name = "identity_key_loader",
+    srcs = ["identity_key_loader.cc"],
+    hdrs = ["identity_key_loader.h"],
+    strip_include_prefix = _INCLUDE_PREFIX,
+    deps = [
+        ":key_loader",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@tink_base//cc/util:secret_data",
+    ],
+)
+
+cc_library(
+    name = "register_identity_key_loader",
+    srcs = ["register_identity_key_loader.cc"],
+    strip_include_prefix = _INCLUDE_PREFIX,
+    deps = [
+        ":identity_key_loader",
+    ],
+    alwayslink = True,
+)

--- a/src/main/cc/wfa/panelmatch/common/crypto/identity_key_loader.cc
+++ b/src/main/cc/wfa/panelmatch/common/crypto/identity_key_loader.cc
@@ -1,0 +1,36 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "wfa/panelmatch/common/crypto/identity_key_loader.h"
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "tink/util/secret_data.h"
+#include "wfa/panelmatch/common/crypto/key_loader.h"
+
+namespace wfa::panelmatch::common::crypto {
+namespace {
+class IdentityKeyLoader : public KeyLoader {
+  virtual absl::StatusOr<::crypto::tink::util::SecretData> LoadKey(
+      absl::string_view key_name) {
+    return ::crypto::tink::util::SecretDataFromStringView(key_name);
+  }
+};
+}  // namespace
+
+void RegisterIdentityKeyLoader() {
+  static auto* key_loader = new IdentityKeyLoader;
+  RegisterGlobalKeyLoader(key_loader);
+}
+}  // namespace wfa::panelmatch::common::crypto

--- a/src/main/cc/wfa/panelmatch/common/crypto/identity_key_loader.h
+++ b/src/main/cc/wfa/panelmatch/common/crypto/identity_key_loader.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_MAIN_CC_WFA_PANELMATCH_COMMON_CRYPTO_IDENTITY_KEY_LOADER_H_
+#define SRC_MAIN_CC_WFA_PANELMATCH_COMMON_CRYPTO_IDENTITY_KEY_LOADER_H_
+
+namespace wfa::panelmatch::common::crypto {
+
+void RegisterIdentityKeyLoader();
+
+}  // namespace wfa::panelmatch::common::crypto
+
+#endif  // SRC_MAIN_CC_WFA_PANELMATCH_COMMON_CRYPTO_IDENTITY_KEY_LOADER_H_

--- a/src/main/cc/wfa/panelmatch/common/crypto/key_loader.cc
+++ b/src/main/cc/wfa/panelmatch/common/crypto/key_loader.cc
@@ -1,0 +1,78 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "wfa/panelmatch/common/crypto/key_loader.h"
+
+#include <string>
+
+#include "absl/status/statusor.h"
+#include "absl/synchronization/mutex.h"
+#include "glog/logging.h"
+#include "tink/util/secret_data.h"
+
+namespace wfa::panelmatch::common::crypto {
+namespace {
+using ::crypto::tink::util::SecretData;
+using ::crypto::tink::util::SecretDataFromStringView;
+
+class KeyLoaderRegistry {
+ public:
+  KeyLoaderRegistry() : key_loader_(nullptr) {}
+
+  void Set(KeyLoader* key_loader) {
+    absl::MutexLock lock(&mu_);
+    CHECK(key_loader != nullptr);
+    CHECK(key_loader_ == nullptr || key_loader_ == key_loader);
+    key_loader_ = key_loader;
+  }
+
+  KeyLoader* Get() {
+    absl::MutexLock lock(&mu_);
+    return key_loader_;
+  }
+
+  void Clear() {
+    absl::MutexLock lock(&mu_);
+    delete key_loader_;
+    key_loader_ = nullptr;
+  }
+
+ private:
+  absl::Mutex mu_;
+  KeyLoader* key_loader_ ABSL_GUARDED_BY(mu_);
+};
+
+KeyLoaderRegistry& GetGlobalKeyLoaderRegistry() {
+  static auto* const registry = new KeyLoaderRegistry;
+  return *registry;
+}
+}  // namespace
+
+bool RegisterGlobalKeyLoader(KeyLoader* key_loader) {
+  GetGlobalKeyLoaderRegistry().Set(key_loader);
+  return true;
+}
+
+KeyLoader* GetGlobalKeyLoader() { return GetGlobalKeyLoaderRegistry().Get(); }
+
+void ClearGlobalKeyLoader() { GetGlobalKeyLoaderRegistry().Clear(); }
+
+absl::StatusOr<SecretData> LoadKey(absl::string_view key_name) {
+  KeyLoader* key_loader = GetGlobalKeyLoader();
+  if (key_loader == nullptr) {
+    return absl::InternalError("No KeyLoader is configured");
+  }
+  return key_loader->LoadKey(key_name);
+}
+}  // namespace wfa::panelmatch::common::crypto

--- a/src/main/cc/wfa/panelmatch/common/crypto/key_loader.h
+++ b/src/main/cc/wfa/panelmatch/common/crypto/key_loader.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 The Cross-Media Measurement Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SRC_MAIN_CC_WFA_PANELMATCH_COMMON_CRYPTO_KEY_LOADER_H_
+#define SRC_MAIN_CC_WFA_PANELMATCH_COMMON_CRYPTO_KEY_LOADER_H_
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "tink/util/secret_data.h"
+
+// This file provides a mechanism for customizing how key material is loaded. It
+// is used in situations where dependency injection is not convenient because,
+// for example, the C++ code is called from the JVM via JNI.
+//
+// Libraries that wish to support accessing the global KeyLoader should call
+// GetGlobalKeyLoader() and verify it's not null before using it.
+//
+// To set the global key loader from another library, the Bazel cc_library
+// should have alwaylink=True enabled and put this in a library somewhere:
+//
+//   static auto registration = RegisterGlobalKeyLoader(new MyCustomKeyLoader);
+
+namespace wfa::panelmatch::common::crypto {
+
+// Loads key material by name.
+class KeyLoader {
+ public:
+  virtual ~KeyLoader() = default;
+
+  virtual absl::StatusOr<::crypto::tink::util::SecretData> LoadKey(
+      absl::string_view key_name) = 0;
+};
+
+// Takes ownership over `key_loader` and sets it to be the KeyLoader used by
+// `LoadKey` for `name`. It is an error to call this multiple times.
+//
+// The destructor of `key_loader` will never be called.
+//
+// The return value will always be true. While using void would be nice, that
+// would make it harder to use because the result of this needs to be assigned
+// to a static variable.
+bool RegisterGlobalKeyLoader(KeyLoader* key_loader);
+
+// Returns nullptr if RegisterGlobalKeyLoader was never called or its parameter
+// if it was called once. The caller does NOT own the return value.
+KeyLoader* GetGlobalKeyLoader();
+
+// If GetGlobalKeyLoader() is null, returns an error. Otherwise, calls LoadKey
+// on it with the given `key_name`.
+absl::StatusOr<::crypto::tink::util::SecretData> LoadKey(
+    absl::string_view key_name);
+
+// Removes any registered KeyLoader. Exposed for testing.
+void ClearGlobalKeyLoader();
+
+}  // namespace wfa::panelmatch::common::crypto
+
+#endif  // SRC_MAIN_CC_WFA_PANELMATCH_COMMON_CRYPTO_KEY_LOADER_H_

--- a/src/main/cc/wfa/panelmatch/common/crypto/register_identity_key_loader.cc
+++ b/src/main/cc/wfa/panelmatch/common/crypto/register_identity_key_loader.cc
@@ -1,0 +1,24 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Link this into a binary to register an IdentityKeyLoader: it will just use
+// the key name as the key material itself.
+
+#include "wfa/panelmatch/common/crypto/identity_key_loader.h"
+
+namespace wfa::panelmatch::common::crypto {
+namespace {
+auto registered = (RegisterIdentityKeyLoader(), true);
+}
+}  // namespace wfa::panelmatch::common::crypto

--- a/src/main/cc/wfa/panelmatch/protocol/crypto/BUILD.bazel
+++ b/src/main/cc/wfa/panelmatch/protocol/crypto/BUILD.bazel
@@ -11,6 +11,7 @@ cc_library(
     strip_include_prefix = _INCLUDE_PREFIX,
     deps = [
         "//src/main/cc/wfa/panelmatch/common/crypto:deterministic_commutative_cipher",
+        "//src/main/cc/wfa/panelmatch/common/crypto:key_loader",
         "//src/main/proto/wfa/panelmatch/protocol/crypto:cryptor_cc_proto",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/memory",

--- a/src/main/cc/wfa/panelmatch/protocol/crypto/deterministic_commutative_encryption_utility.cc
+++ b/src/main/cc/wfa/panelmatch/protocol/crypto/deterministic_commutative_encryption_utility.cc
@@ -28,18 +28,23 @@
 #include "common_cpp/time/started_thread_cpu_timer.h"
 #include "tink/util/secret_data.h"
 #include "wfa/panelmatch/common/crypto/deterministic_commutative_cipher.h"
+#include "wfa/panelmatch/common/crypto/key_loader.h"
 #include "wfa/panelmatch/protocol/crypto/cryptor.pb.h"
 
 namespace wfa::panelmatch::protocol::crypto {
+namespace {
 using ::crypto::tink::util::SecretData;
 using ::crypto::tink::util::SecretDataFromStringView;
+using ::wfa::panelmatch::common::crypto::LoadKey;
 using ::wfa::panelmatch::common::crypto::NewDeterministicCommutativeCipher;
+}  // namespace
 
 absl::StatusOr<CryptorEncryptResponse> DeterministicCommutativeEncrypt(
     const CryptorEncryptRequest& request) {
   StartedThreadCpuTimer timer;
   CryptorEncryptResponse response;
-  SecretData key = SecretDataFromStringView(request.encryption_key());
+
+  ASSIGN_OR_RETURN(SecretData key, LoadKey(request.encryption_key()));
   ASSIGN_OR_RETURN(auto cipher, NewDeterministicCommutativeCipher(key));
 
   for (absl::string_view plaintext : request.plaintexts()) {
@@ -55,7 +60,8 @@ absl::StatusOr<CryptorDecryptResponse> DeterministicCommutativeDecrypt(
     const CryptorDecryptRequest& request) {
   StartedThreadCpuTimer timer;
   CryptorDecryptResponse response;
-  SecretData key = SecretDataFromStringView(request.encryption_key());
+
+  ASSIGN_OR_RETURN(SecretData key, LoadKey(request.encryption_key()));
   ASSIGN_OR_RETURN(auto cipher, NewDeterministicCommutativeCipher(key));
 
   for (absl::string_view ciphertext : request.encrypted_texts()) {
@@ -71,7 +77,8 @@ absl::StatusOr<CryptorReEncryptResponse> DeterministicCommutativeReEncrypt(
     const CryptorReEncryptRequest& request) {
   StartedThreadCpuTimer timer;
   CryptorReEncryptResponse response;
-  SecretData key = SecretDataFromStringView(request.encryption_key());
+
+  ASSIGN_OR_RETURN(SecretData key, LoadKey(request.encryption_key()));
   ASSIGN_OR_RETURN(auto cipher, NewDeterministicCommutativeCipher(key));
 
   for (absl::string_view ciphertext : request.encrypted_texts()) {

--- a/src/main/swig/wfanet/panelmatch/client/eventpreprocessing/BUILD.bazel
+++ b/src/main/swig/wfanet/panelmatch/client/eventpreprocessing/BUILD.bazel
@@ -12,5 +12,9 @@ java_wrap_cc(
     package = "org.wfanet.panelmatch.client.eventpreprocessing",
     deps = [
         "//src/main/cc/wfa/panelmatch/client/eventpreprocessing:preprocess_events_wrapper",
+
+        # To change the KeyLoader in use, replace this with a cc_library that
+        # statically registers a different KeyLoader.
+        "//src/main/cc/wfa/panelmatch/common/crypto:register_identity_key_loader",
     ],
 )

--- a/src/main/swig/wfanet/panelmatch/protocol/crypto/BUILD.bazel
+++ b/src/main/swig/wfanet/panelmatch/protocol/crypto/BUILD.bazel
@@ -12,5 +12,9 @@ java_wrap_cc(
     package = "org.wfanet.panelmatch.protocol.crypto",
     deps = [
         "//src/main/cc/wfa/panelmatch/protocol/crypto:deterministic_commutative_encryption_utility_wrapper",
+
+        # To change the KeyLoader in use, replace this with a cc_library that
+        # statically registers a different KeyLoader.
+        "//src/main/cc/wfa/panelmatch/common/crypto:register_identity_key_loader",
     ],
 )

--- a/src/test/cc/wfa/panelmatch/client/eventpreprocessing/BUILD.bazel
+++ b/src/test/cc/wfa/panelmatch/client/eventpreprocessing/BUILD.bazel
@@ -5,6 +5,7 @@ cc_test(
     srcs = ["preprocess_events_test.cc"],
     deps = [
         "//src/main/cc/wfa/panelmatch/client/eventpreprocessing:preprocess_events",
+        "//src/main/cc/wfa/panelmatch/common/crypto:register_identity_key_loader",
         "//src/main/cc/wfa/panelmatch/protocol/crypto:event_data_preprocessor",
         "//src/main/proto/wfa/panelmatch/client/eventpreprocessing:preprocess_events_cc_proto",
         "@com_google_absl//absl/base:core_headers",

--- a/src/test/cc/wfa/panelmatch/common/crypto/BUILD.bazel
+++ b/src/test/cc/wfa/panelmatch/common/crypto/BUILD.bazel
@@ -1,6 +1,30 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
 
 cc_test(
+    name = "aes_test",
+    srcs = ["aes_test.cc"],
+    deps = [
+        "//src/main/cc/wfa/panelmatch/common/crypto:aes",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+        "@tink_base//cc/util:secret_data",
+        "@tink_cc//subtle",
+        "@wfa_common_cpp//src/main/cc/common_cpp/testing:status",
+    ],
+)
+
+cc_test(
+    name = "aes_with_hkdf_test",
+    srcs = ["aes_with_hkdf_test.cc"],
+    deps = [
+        "//src/main/cc/wfa/panelmatch/common/crypto:aes_with_hkdf",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+        "@wfa_common_cpp//src/main/cc/common_cpp/testing:status",
+    ],
+)
+
+cc_test(
     name = "deterministic_commutative_cipher_test",
     srcs = ["deterministic_commutative_cipher_test.cc"],
     deps = [
@@ -19,14 +43,14 @@ cc_test(
 )
 
 cc_test(
-    name = "aes_test",
-    srcs = ["aes_test.cc"],
+    name = "ec_commutative_cipher_key_generator",
+    srcs = ["ec_commutative_cipher_key_generator_test.cc"],
     deps = [
-        "//src/main/cc/wfa/panelmatch/common/crypto:aes",
-        "@com_google_absl//absl/strings",
+        "//src/main/cc/wfa/panelmatch/common/crypto:ec_commutative_cipher_key_generator",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_googletest//:gtest_main",
+        "@com_google_private_join_and_compute//private_join_and_compute/crypto:ec_commutative_cipher",
         "@tink_base//cc/util:secret_data",
-        "@tink_cc//subtle",
         "@wfa_common_cpp//src/main/cc/common_cpp/testing:status",
     ],
 )
@@ -47,12 +71,30 @@ cc_test(
 )
 
 cc_test(
-    name = "aes_with_hkdf_test",
-    srcs = ["aes_with_hkdf_test.cc"],
+    name = "key_loader_test",
+    srcs = ["key_loader_test.cc"],
     deps = [
-        "//src/main/cc/wfa/panelmatch/common/crypto:aes_with_hkdf",
+        "//src/main/cc/wfa/panelmatch/common/crypto:key_loader",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
+        "@tink_base//cc/util:secret_data",
+        "@wfa_common_cpp//src/main/cc/common_cpp/testing:status",
+    ],
+)
+
+cc_test(
+    name = "identity_key_loader_test",
+    srcs = ["identity_key_loader_test.cc"],
+    deps = [
+        "//src/main/cc/wfa/panelmatch/common/crypto:key_loader",
+        "//src/main/cc/wfa/panelmatch/common/crypto:register_identity_key_loader",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_googletest//:gtest_main",
+        "@tink_base//cc/util:secret_data",
         "@wfa_common_cpp//src/main/cc/common_cpp/testing:status",
     ],
 )
@@ -65,19 +107,6 @@ cc_test(
         "@com_google_googletest//:gtest_main",
         "@tink_base//cc/util:secret_data",
         "@wfa_common_cpp//src/main/cc/common_cpp/fingerprinters",
-    ],
-)
-
-cc_test(
-    name = "ec_commutative_cipher_key_generator",
-    srcs = ["ec_commutative_cipher_key_generator_test.cc"],
-    deps = [
-        "//src/main/cc/wfa/panelmatch/common/crypto:ec_commutative_cipher_key_generator",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_googletest//:gtest_main",
-        "@com_google_private_join_and_compute//private_join_and_compute/crypto:ec_commutative_cipher",
-        "@tink_base//cc/util:secret_data",
-        "@wfa_common_cpp//src/main/cc/common_cpp/testing:status",
     ],
 )
 

--- a/src/test/cc/wfa/panelmatch/common/crypto/identity_key_loader_test.cc
+++ b/src/test/cc/wfa/panelmatch/common/crypto/identity_key_loader_test.cc
@@ -1,0 +1,33 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "common_cpp/testing/status_macros.h"
+#include "gtest/gtest.h"
+#include "tink/util/secret_data.h"
+#include "wfa/panelmatch/common/crypto/key_loader.h"
+
+namespace wfa::panelmatch::common::crypto {
+namespace {
+using ::crypto::tink::util::SecretData;
+using ::crypto::tink::util::SecretDataAsStringView;
+
+TEST(IdentityKeyLoaderTest, RegistersAnIdentityKeyLoader) {
+  ASSERT_OK_AND_ASSIGN(SecretData key_material, LoadKey("abc"));
+  EXPECT_EQ(SecretDataAsStringView(key_material), "abc");
+}
+}  // namespace
+}  // namespace wfa::panelmatch::common::crypto

--- a/src/test/cc/wfa/panelmatch/common/crypto/key_loader_test.cc
+++ b/src/test/cc/wfa/panelmatch/common/crypto/key_loader_test.cc
@@ -1,0 +1,66 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "wfa/panelmatch/common/crypto/key_loader.h"
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+#include "common_cpp/testing/status_macros.h"
+#include "gtest/gtest.h"
+#include "tink/util/secret_data.h"
+
+namespace wfa::panelmatch::common::crypto {
+namespace {
+using ::crypto::tink::util::SecretData;
+using ::crypto::tink::util::SecretDataFromStringView;
+
+SecretData GetTestSecretData(absl::string_view key_name) {
+  return SecretDataFromStringView(absl::StrCat("Key material for: ", key_name));
+}
+
+class FakeKeyLoader : public KeyLoader {
+ public:
+  absl::StatusOr<SecretData> LoadKey(absl::string_view key_name) override {
+    return GetTestSecretData(key_name);
+  }
+};
+
+auto* some_fake_key_loader = new FakeKeyLoader;
+
+auto unused = RegisterGlobalKeyLoader(some_fake_key_loader);
+
+TEST(KeyLoaderTest, FakeKeyLoader) {
+  EXPECT_EQ(GetGlobalKeyLoader(), some_fake_key_loader);
+  ASSERT_OK_AND_ASSIGN(SecretData result, LoadKey("abc"));
+  EXPECT_EQ(result, GetTestSecretData("abc"));
+}
+
+TEST(KeyLoaderTest, NoKeyLoader) {
+  ClearGlobalKeyLoader();
+  EXPECT_EQ(GetGlobalKeyLoader(), nullptr);
+  RegisterGlobalKeyLoader(some_fake_key_loader);
+}
+
+TEST(KeyLoaderDeathTest, Reregister) {
+  EXPECT_DEATH(RegisterGlobalKeyLoader(new FakeKeyLoader), "");
+}
+
+TEST(KeyLoaderDeathTest, RegisterNullptr) {
+  EXPECT_DEATH(RegisterGlobalKeyLoader(nullptr), "");
+}
+
+}  // namespace
+}  // namespace wfa::panelmatch::common::crypto

--- a/src/test/cc/wfa/panelmatch/protocol/crypto/BUILD.bazel
+++ b/src/test/cc/wfa/panelmatch/protocol/crypto/BUILD.bazel
@@ -4,6 +4,7 @@ cc_test(
     name = "deterministic_commutative_encryption_utility_test",
     srcs = ["deterministic_commutative_encryption_utility_test.cc"],
     deps = [
+        "//src/main/cc/wfa/panelmatch/common/crypto:register_identity_key_loader",
         "//src/main/cc/wfa/panelmatch/protocol/crypto:deterministic_commutative_encryption_utility",
         "//src/main/proto/wfa/panelmatch/protocol/crypto:cryptor_cc_proto",
         "@com_google_absl//absl/base:core_headers",
@@ -25,6 +26,7 @@ cc_test(
         "//src/main/cc/wfa/panelmatch/common/crypto:aes_with_hkdf",
         "//src/main/cc/wfa/panelmatch/common/crypto:deterministic_commutative_cipher",
         "//src/main/cc/wfa/panelmatch/common/crypto:hkdf",
+        "//src/main/cc/wfa/panelmatch/common/crypto:register_identity_key_loader",
         "//src/main/cc/wfa/panelmatch/protocol/crypto:event_data_preprocessor",
         "@com_google_googletest//:gtest_main",
         "@tink_base//cc/util:secret_data",


### PR DESCRIPTION
This provides a hook to inject customization into JNIed C++ without
needing to modify the code. Instead, it just requires clients to link in
a library that statically registers a "KeyLoader", which can be used to
load crypto keys in different ways.

https://rally1.rallydev.com/#/604612930531ud/workviews/collection?detail=%2Ftask%2F607976795807&itemRef=%2Fhierarchicalrequirement%2F607976794839&previousTokens=%2F604612930531ud%2Fworkviews%3Fdetail%3D%252Fuserstory%252F607976794839%26view%3D295a0465-1160-4b45-92f5-4c1c70030166&project=%2Fproject%2F604612930531&ref=%2Fhierarchicalrequirement%2F607976794839&relationship=tasks&fdp=true?fdp=true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/101)
<!-- Reviewable:end -->
