### PR TITLE
Fix .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 # Bazel convenience symlinks.
-/bazel-*/
+/bazel-*
 
 # Bazel IntelliJ projects.
-.ijwb
-.clwb
+/.ijwb/
+/.clwb/
 
 # IntelliJ projects.
-.idea/
-*.iml
+/.idea/
+/*.iml
 


### PR DESCRIPTION
A leading slash means that the pattern is relative to the directory
level of the .gitignore file.

A trailing slash matches directories -- but bazel-* are symlinks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/102)
<!-- Reviewable:end -->
