### PR TITLE
Add support for dictionary-based compression

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/DeterministicCommutativeCipherKeyProvider.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/DeterministicCommutativeCipherKeyProvider.kt
@@ -1,0 +1,23 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.eventpreprocessing
+
+import com.google.protobuf.ByteString
+import java.io.Serializable
+
+/** Type-safe provider for the deterministic, commutative cipher key. */
+interface DeterministicCommutativeCipherKeyProvider : Serializable {
+  fun get(): ByteString
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/EventAggregator.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/EventAggregator.kt
@@ -1,0 +1,23 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.eventpreprocessing
+
+import com.google.protobuf.ByteString
+import java.io.Serializable
+
+/** Type-safe interface for combining event data. */
+interface EventAggregator : Serializable {
+  fun combine(events: Iterable<ByteString>): ByteString
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/EventAggregatorTrainer.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/EventAggregatorTrainer.kt
@@ -1,0 +1,37 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.eventpreprocessing
+
+import com.google.protobuf.ByteString
+import java.io.Serializable
+
+/**
+ * [EventAggregator] factory that supports training.
+ *
+ * This is to enable dictionary-based compression. The output dictionary should be provided to
+ * whichever library needs to disaggregate.
+ */
+interface EventAggregatorTrainer : Serializable {
+  data class TrainedEventAggregator(
+    val eventAggregator: EventAggregator,
+    val dictionary: ByteString
+  )
+
+  /** Hint suggesting how many elements should be in the sample. */
+  val preferredSampleSize: Int
+
+  /** Builds a dictionary and an [EventAggregator] that uses it. */
+  fun train(eventsSample: Iterable<ByteString>): TrainedEventAggregator
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/EventAggregators.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/EventAggregators.kt
@@ -1,0 +1,67 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.eventpreprocessing
+
+import com.google.protobuf.ByteString
+import org.apache.beam.sdk.transforms.Sample
+import org.apache.beam.sdk.transforms.View
+import org.apache.beam.sdk.values.KV
+import org.apache.beam.sdk.values.PCollection
+import org.apache.beam.sdk.values.PCollectionView
+import org.wfanet.panelmatch.client.eventpreprocessing.EventAggregatorTrainer.TrainedEventAggregator
+import org.wfanet.panelmatch.common.beam.groupByKey
+import org.wfanet.panelmatch.common.beam.kvOf
+import org.wfanet.panelmatch.common.beam.map
+import org.wfanet.panelmatch.common.beam.parDoWithSideInput
+import org.wfanet.panelmatch.common.beam.values
+
+/**
+ * First use [Sample.any] -- which is not guaranteed to be uniform -- to significantly over-sample
+ * then use [Sample.fixedSizeGlobally], which is uniform random but inefficient on lots of data.
+ *
+ * We coarsely sample 10 times as much data as is necessary; this should be adjusted experimentally.
+ */
+private const val OVERSAMPLING_FACTOR = 10L
+
+/** The results of training an [EventAggregator] and then applying it to a [PCollection]. */
+data class AggregatedEvents(
+  val events: PCollection<KV<ByteString, ByteString>>,
+  val dictionary: PCollectionView<ByteString>
+)
+
+/** Trains an [EventAggregator] and applies it to a [PCollection]. */
+fun EventAggregatorTrainer.aggregateByKey(
+  events: PCollection<KV<ByteString, ByteString>>
+): AggregatedEvents {
+  val trainedEventAggregator: PCollection<TrainedEventAggregator> =
+    events
+      .values()
+      .apply("Rough Sample", Sample.any(OVERSAMPLING_FACTOR * preferredSampleSize))
+      .apply("Uniform Sample", Sample.fixedSizeGlobally(preferredSampleSize))
+      .map { train(it) }
+      .setCoder(TrainedEventsAggregatorCoder.of())
+
+  val eventAggregatorView =
+    trainedEventAggregator.map { it.eventAggregator }.apply(View.asSingleton())
+
+  val aggregatedEvents: PCollection<KV<ByteString, ByteString>> =
+    events.groupByKey().parDoWithSideInput(eventAggregatorView) { keyAndEvents, eventAggregator ->
+      yield(kvOf(keyAndEvents.key, eventAggregator.combine(keyAndEvents.value)))
+    }
+
+  val dictionaryView = trainedEventAggregator.map { it.dictionary }.apply(View.asSingleton())
+
+  return AggregatedEvents(aggregatedEvents, dictionaryView)
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/HkdfPepperProvider.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/HkdfPepperProvider.kt
@@ -1,0 +1,23 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.eventpreprocessing
+
+import com.google.protobuf.ByteString
+import java.io.Serializable
+
+/** Type-safe provider for the HKDF pepper. */
+interface HkdfPepperProvider : Serializable {
+  fun get(): ByteString
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/IdentifierHashPepperProvider.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/IdentifierHashPepperProvider.kt
@@ -18,21 +18,6 @@ import com.google.protobuf.ByteString
 import java.io.Serializable
 
 /** Type-safe provider for the identifier hash pepper. */
-fun interface IdentifierHashPepperProvider : Serializable {
+interface IdentifierHashPepperProvider : Serializable {
   fun get(): ByteString
-}
-
-/** Type-safe provider for the HKDF pepper. */
-fun interface HkdfPepperProvider : Serializable {
-  fun get(): ByteString
-}
-
-/** Type-safe provider for the deterministic, commutative cipher key. */
-fun interface DeterministicCommutativeCipherKeyProvider : Serializable {
-  fun get(): ByteString
-}
-
-/** Type-safe interface for combining event data. */
-fun interface EventAggregator : Serializable {
-  fun combine(events: Iterable<ByteString>): ByteString
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/TrainedEventsAggregatorCoder.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/TrainedEventsAggregatorCoder.kt
@@ -1,0 +1,46 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.eventpreprocessing
+
+import java.io.InputStream
+import java.io.OutputStream
+import org.apache.beam.sdk.coders.AtomicCoder
+import org.apache.beam.sdk.coders.KvCoder
+import org.apache.beam.sdk.coders.SerializableCoder
+import org.apache.beam.sdk.extensions.protobuf.ByteStringCoder
+import org.wfanet.panelmatch.client.eventpreprocessing.EventAggregatorTrainer.TrainedEventAggregator
+import org.wfanet.panelmatch.common.beam.kvOf
+
+/** Coder for [TrainedEventAggregator]. */
+internal class TrainedEventsAggregatorCoder : AtomicCoder<TrainedEventAggregator>() {
+  private val serializableCoder = SerializableCoder.of(EventAggregator::class.java)
+  private val byteStringCoder = ByteStringCoder.of()
+  private val kvCoder = KvCoder.of(serializableCoder, byteStringCoder)
+
+  override fun encode(value: TrainedEventAggregator, outStream: OutputStream) {
+    kvCoder.encode(kvOf(value.eventAggregator, value.dictionary), outStream)
+  }
+
+  override fun decode(inStream: InputStream): TrainedEventAggregator {
+    val kv = kvCoder.decode(inStream)
+    return TrainedEventAggregator(checkNotNull(kv.key), checkNotNull(kv.value))
+  }
+
+  companion object {
+    fun of(): TrainedEventsAggregatorCoder {
+      return TrainedEventsAggregatorCoder()
+    }
+  }
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/UncompressedEventAggregatorTrainer.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/UncompressedEventAggregatorTrainer.kt
@@ -1,0 +1,31 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.eventpreprocessing
+
+import com.google.protobuf.ByteString
+import org.wfanet.panelmatch.client.eventpreprocessing.EventAggregatorTrainer.TrainedEventAggregator
+
+/**
+ * Trivial trainer for [UncompressedEventAggregator].
+ *
+ * WARNING: since this does no compression, you likely do not want to use it in production.
+ */
+class UncompressedEventAggregatorTrainer : EventAggregatorTrainer {
+  override val preferredSampleSize: Int = 0
+
+  override fun train(eventsSample: Iterable<ByteString>): TrainedEventAggregator {
+    return TrainedEventAggregator(UncompressedEventAggregator(), ByteString.EMPTY)
+  }
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/deploy/gcloud/PreprocessEventsMain.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/deploy/gcloud/PreprocessEventsMain.kt
@@ -33,7 +33,7 @@ import org.apache.beam.sdk.values.PCollection
 import org.wfanet.panelmatch.client.eventpreprocessing.HardCodedDeterministicCommutativeCipherKeyProvider
 import org.wfanet.panelmatch.client.eventpreprocessing.HardCodedHkdfPepperProvider
 import org.wfanet.panelmatch.client.eventpreprocessing.HardCodedIdentifierHashPepperProvider
-import org.wfanet.panelmatch.client.eventpreprocessing.UncompressedEventAggregator
+import org.wfanet.panelmatch.client.eventpreprocessing.UncompressedEventAggregatorTrainer
 import org.wfanet.panelmatch.client.eventpreprocessing.preprocessEventsInPipeline
 import org.wfanet.panelmatch.common.beam.kvOf
 import org.wfanet.panelmatch.common.beam.map
@@ -91,7 +91,7 @@ fun main(args: Array<String>) {
       HardCodedIdentifierHashPepperProvider(options.identifierHashPepper.toByteString()),
       HardCodedHkdfPepperProvider(options.hkdfPepper.toByteString()),
       HardCodedDeterministicCommutativeCipherKeyProvider(options.cryptokey.toByteString()),
-      UncompressedEventAggregator()
+      UncompressedEventAggregatorTrainer()
     )
 
   writeToBigQuery(encryptedEvents, options.bigQueryOutputTable)

--- a/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/testing/BUILD.bazel
@@ -13,6 +13,8 @@ kt_jvm_library(
     deps = [
         "//src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing",
         "//src/main/kotlin/org/wfanet/panelmatch/common",
+        "//src/main/kotlin/org/wfanet/panelmatch/common/beam",
+        "//src/main/kotlin/org/wfanet/panelmatch/common/beam/testing",
         "//src/main/proto/wfa/panelmatch/client/eventpreprocessing:preprocess_events_kt_jvm_proto",
         "//src/main/proto/wfa/panelmatch/client/privatemembership:database_java_proto",
         "//src/main/proto/wfa/panelmatch/client/privatemembership:query_evaluator_java_proto",

--- a/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/testing/Events.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/testing/Events.kt
@@ -1,0 +1,38 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.eventpreprocessing.testing
+
+import com.google.protobuf.ByteString
+import org.apache.beam.sdk.coders.Coder
+import org.apache.beam.sdk.coders.KvCoder
+import org.apache.beam.sdk.extensions.protobuf.ByteStringCoder
+import org.apache.beam.sdk.values.KV
+import org.apache.beam.sdk.values.PCollection
+import org.wfanet.panelmatch.common.beam.kvOf
+import org.wfanet.panelmatch.common.beam.testing.BeamTestBase
+import org.wfanet.panelmatch.common.toByteString
+
+fun BeamTestBase.eventsOf(
+  vararg pairs: Pair<String, String>
+): PCollection<KV<ByteString, ByteString>> {
+  @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
+  val coder: Coder<KV<ByteString, ByteString>> =
+    KvCoder.of(ByteStringCoder.of(), ByteStringCoder.of())
+  return pcollectionOf(
+    "Create Events",
+    *pairs.map { kvOf(it.first.toByteString(), it.second.toByteString()) }.toTypedArray(),
+    coder = coder
+  )
+}

--- a/src/test/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/BUILD.bazel
@@ -1,22 +1,6 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 kt_jvm_test(
-    name = "JniPreprocessEventsTest",
-    srcs = ["JniPreprocessEventsTest.kt"],
-    test_class = "org.wfanet.panelmatch.client.eventpreprocessing.JniPreprocessEventsTest",
-    deps = [
-        "//src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing",
-        "//src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/testing",
-        "//src/main/kotlin/org/wfanet/panelmatch/common",
-        "//src/main/proto/wfa/panelmatch/client/eventpreprocessing:preprocess_events_java_proto",
-        "@wfa_common_jvm//imports/java/com/google/common/truth",
-        "@wfa_common_jvm//imports/java/com/google/protobuf",
-        "@wfa_common_jvm//imports/java/org/junit",
-        "@wfa_common_jvm//imports/kotlin/kotlin/test",
-    ],
-)
-
-kt_jvm_test(
     name = "BatchingDoFnTest",
     srcs = ["BatchingDoFnTest.kt"],
     test_class = "org.wfanet.panelmatch.client.eventpreprocessing.BatchingDoFnTest",
@@ -47,22 +31,6 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
-    name = "EncryptEventsTest",
-    srcs = ["EncryptEventsTest.kt"],
-    test_class = "org.wfanet.panelmatch.client.eventpreprocessing.EncryptEventsTest",
-    deps = [
-        "//imports/java/com/google/common:guava",
-        "//src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing",
-        "//src/main/kotlin/org/wfanet/panelmatch/common",
-        "//src/main/proto/wfa/panelmatch/client/eventpreprocessing:preprocess_events_kt_jvm_proto",
-        "@wfa_common_jvm//imports/java/com/google/common/truth",
-        "@wfa_common_jvm//imports/java/com/google/protobuf",
-        "@wfa_common_jvm//imports/java/org/junit",
-        "@wfa_common_jvm//imports/kotlin/kotlin/test",
-    ],
-)
-
-kt_jvm_test(
     name = "EncryptEventsDoFnTest",
     srcs = ["EncryptEventsDoFnTest.kt"],
     test_class = "org.wfanet.panelmatch.client.eventpreprocessing.EncryptEventsDoFnTest",
@@ -81,6 +49,57 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "EncryptEventsTest",
+    srcs = ["EncryptEventsTest.kt"],
+    test_class = "org.wfanet.panelmatch.client.eventpreprocessing.EncryptEventsTest",
+    deps = [
+        "//imports/java/com/google/common:guava",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing",
+        "//src/main/kotlin/org/wfanet/panelmatch/common",
+        "//src/main/proto/wfa/panelmatch/client/eventpreprocessing:preprocess_events_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+    ],
+)
+
+kt_jvm_test(
+    name = "EventAggregatorsTest",
+    srcs = ["EventAggregatorsTest.kt"],
+    test_class = "org.wfanet.panelmatch.client.eventpreprocessing.EventAggregatorsTest",
+    deps = [
+        "//imports/java/com/google/common:guava",
+        "//imports/java/org/apache/beam:core",
+        "//imports/java/org/apache/beam/extensions:protobuf",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/testing",
+        "//src/main/kotlin/org/wfanet/panelmatch/common",
+        "//src/main/kotlin/org/wfanet/panelmatch/common/beam",
+        "//src/main/kotlin/org/wfanet/panelmatch/common/beam/testing",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//imports/java/org/junit",
+    ],
+)
+
+kt_jvm_test(
+    name = "JniPreprocessEventsTest",
+    srcs = ["JniPreprocessEventsTest.kt"],
+    test_class = "org.wfanet.panelmatch.client.eventpreprocessing.JniPreprocessEventsTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/testing",
+        "//src/main/kotlin/org/wfanet/panelmatch/common",
+        "//src/main/proto/wfa/panelmatch/client/eventpreprocessing:preprocess_events_java_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/com/google/protobuf",
+        "@wfa_common_jvm//imports/java/org/junit",
+        "@wfa_common_jvm//imports/kotlin/kotlin/test",
+    ],
+)
+
+kt_jvm_test(
     name = "PreprocessEventsInPipelineTest",
     srcs = ["PreprocessEventsInPipelineTest.kt"],
     test_class = "org.wfanet.panelmatch.client.eventpreprocessing.PreprocessEventsInPipelineTest",
@@ -89,6 +108,7 @@ kt_jvm_test(
         "//imports/java/org/apache/beam:core",
         "//imports/java/org/apache/beam/extensions:protobuf",
         "//src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing",
+        "//src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/testing",
         "//src/main/kotlin/org/wfanet/panelmatch/common",
         "//src/main/kotlin/org/wfanet/panelmatch/common/beam",
         "//src/main/kotlin/org/wfanet/panelmatch/common/beam/testing",

--- a/src/test/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/EventAggregatorsTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/EventAggregatorsTest.kt
@@ -1,0 +1,82 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.eventpreprocessing
+
+import com.google.common.truth.Truth.assertThat
+import com.google.protobuf.ByteString
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.panelmatch.client.eventpreprocessing.EventAggregatorTrainer.TrainedEventAggregator
+import org.wfanet.panelmatch.client.eventpreprocessing.testing.eventsOf
+import org.wfanet.panelmatch.common.beam.kvOf
+import org.wfanet.panelmatch.common.beam.map
+import org.wfanet.panelmatch.common.beam.testing.BeamTestBase
+import org.wfanet.panelmatch.common.beam.testing.assertThat
+import org.wfanet.panelmatch.common.toByteString
+
+@RunWith(JUnit4::class)
+class EventAggregatorsTest : BeamTestBase() {
+
+  @Test
+  fun aggregateByKey() {
+    val events = eventsOf("A" to "W", "A" to "X", "B" to "Y", "C" to "Z")
+
+    val aggregatedEvents: AggregatedEvents = FakeEventAggregatorTrainer().aggregateByKey(events)
+
+    val eventsAsStrings =
+      aggregatedEvents.events.map { kvOf(it.key.toStringUtf8(), it.value.toStringUtf8()) }
+    assertThat(eventsAsStrings)
+      .containsInAnyOrder(
+        kvOf("A", "Combined: W, X"),
+        kvOf("B", "Combined: Y"),
+        kvOf("C", "Combined: Z"),
+      )
+
+    assertThat(aggregatedEvents.dictionary).satisfies {
+      val dictionary = it.toList()
+      assertThat(dictionary).hasSize(1)
+      assertThat(dictionary[0].toStringUtf8())
+        .isAnyOf(
+          "Dictionary: W, X, Y",
+          "Dictionary: W, X, Z",
+          "Dictionary: W, Y, Z",
+          "Dictionary: X, Y, Z"
+        )
+      null
+    }
+  }
+}
+
+private class FakeEventAggregator : EventAggregator {
+  override fun combine(events: Iterable<ByteString>): ByteString {
+    return "Combined: ${events.sortAndJoin()}".toByteString()
+  }
+}
+
+private class FakeEventAggregatorTrainer : EventAggregatorTrainer {
+  override val preferredSampleSize: Int = 3
+
+  override fun train(eventsSample: Iterable<ByteString>): TrainedEventAggregator {
+    return TrainedEventAggregator(
+      FakeEventAggregator(),
+      "Dictionary: ${eventsSample.sortAndJoin()}".toByteString()
+    )
+  }
+}
+
+private fun Iterable<ByteString>.sortAndJoin(): String {
+  return map { it.toStringUtf8() }.sorted().joinToString(", ")
+}


### PR DESCRIPTION
This introduces an EventAggregatorTrainer interface as a way to work with dictionary-based compression:

- Apache Beam will sample some number of values
- These will be passed to an EventAggregatorTrainer
- This will produce a "dictionary" and an EventAggregator
- The dictionary should be shared with the partner for disaggregation

Next steps: extracting the dictionary, implementing a specific type of compression.

https://rally1.rallydev.com/#/?detail=/task/607295619591&fdp=true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/107)
<!-- Reviewable:end -->
