### PR TITLE
Implement Exchange Step double signature validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /.idea/
 /*.iml
 
+# VIM swap files
+**/*.swp

--- a/build/maven_deps.bzl
+++ b/build/maven_deps.bzl
@@ -31,6 +31,7 @@ _ARTIFACTS = artifacts.dict_to_list({
     "com.google.cloud:google-cloud-nio": "0.122.0",
     "com.google.cloud:google-cloud-storage": "1.118.0",
     "com.google.code.gson:gson": "2.8.6",
+    "com.google.crypto.tink:tink": "1.6.0",
     "com.google.guava:guava": "30.1.1-jre",
     "com.google.http-client:google-http-client": "1.39.2",
     "io.grpc:grpc-api": "1.37.0",

--- a/build/repositories.bzl
+++ b/build/repositories.bzl
@@ -48,9 +48,9 @@ def panel_exchange_client_repositories():
 
     http_archive(
         name = "wfa_measurement_proto",
-        sha256 = "94b6ed87c4c9917da80fc4f5803b2c62a93767f433bfd7f25e5c6c9dc355aa38",
-        strip_prefix = "cross-media-measurement-api-640987b5196e26fe717a47875f603360d6c11346",
-        url = "https://github.com/world-federation-of-advertisers/cross-media-measurement-api/archive/640987b5196e26fe717a47875f603360d6c11346.tar.gz",
+        sha256 = "9dbefb535010f08d1133c122a30d406b48fe6149d264ca9c1aa508a1afd2f818",
+        strip_prefix = "cross-media-measurement-api-9f3a39e9d0270a8e0f7db7a94740e581eb937f70",
+        url = "https://github.com/world-federation-of-advertisers/cross-media-measurement-api/archive/9f3a39e9d0270a8e0f7db7a94740e581eb937f70.tar.gz",
     )
 
     http_archive(
@@ -58,6 +58,13 @@ def panel_exchange_client_repositories():
         sha256 = "34c15134d7293fc38df6ed254b55ee912c7479c396178b7f6499b7e5351aeeec",
         strip_prefix = "rules_swig-653d1bdcec85a9373df69920f35961150cf4b1b6",
         url = "https://github.com/world-federation-of-advertisers/rules_swig/archive/653d1bdcec85a9373df69920f35961150cf4b1b6.tar.gz",
+    )
+
+    http_archive(
+        name = "wfa_consent_signaling_client",
+        sha256 = "a97c4b1350eaca3e33eacf5f91611c4009c90a7abf7b2db1394ec0fa8bbaa5e0",
+        strip_prefix = "consent-signaling-client-0.6.0",
+        url = "https://github.com/world-federation-of-advertisers/consent-signaling-client/archive/refs/tags/v0.6.0.tar.gz",
     )
 
     http_archive(

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
@@ -14,6 +14,7 @@
 
 package org.wfanet.panelmatch.client.deploy
 
+import java.security.cert.X509Certificate
 import java.time.Clock
 import kotlinx.coroutines.runBlocking
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptsGrpcKt.ExchangeStepAttemptsCoroutineStub
@@ -46,6 +47,10 @@ abstract class ExchangeWorkflowDaemon : Runnable {
 
   /** [VerifiedStorageClient] for payloads that should NOT shared with the other party. */
   abstract val privateStorage: VerifiedStorageClient
+
+  abstract val dataProviderCertificate: X509Certificate
+
+  abstract val modelProviderCertificate: X509Certificate
 
   override fun run() {
     val clientCerts =
@@ -97,7 +102,12 @@ abstract class ExchangeWorkflowDaemon : Runnable {
     val exchangeStepLauncher =
       ExchangeStepLauncher(
         apiClient = grpcApiClient,
-        validator = ExchangeStepValidatorImpl(),
+        validator =
+          ExchangeStepValidatorImpl(
+            flags.partyType,
+            dataProviderCertificate,
+            modelProviderCertificate
+          ),
         jobLauncher = launcher
       )
 

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonMain.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonMain.kt
@@ -14,6 +14,7 @@
 
 package org.wfanet.panelmatch.client.deploy
 
+import java.security.cert.X509Certificate
 import org.wfanet.measurement.common.commandLineMain
 import org.wfanet.panelmatch.client.storage.VerifiedStorageClient
 import picocli.CommandLine
@@ -28,6 +29,10 @@ private object UnimplementedExchangeWorkflowDaemon : ExchangeWorkflowDaemon() {
   override val sharedStorage: VerifiedStorageClient
     get() = TODO("Not yet implemented")
   override val privateStorage: VerifiedStorageClient
+    get() = TODO("Not yet implemented")
+  override val dataProviderCertificate: X509Certificate
+    get() = TODO("Not yet implemented")
+  override val modelProviderCertificate: X509Certificate
     get() = TODO("Not yet implemented")
 }
 

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/BUILD.bazel
@@ -20,6 +20,8 @@ kt_jvm_library(
         "@wfa_common_jvm//imports/java/com/google/protobuf",
         "@wfa_common_jvm//imports/kotlin/kotlinx/coroutines:core",
         "@wfa_common_jvm//src/main/kotlin/org/wfanet/measurement/common/grpc",
+        "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/dataprovider",
+        "@wfa_consent_signaling_client//src/main/kotlin/org/wfanet/measurement/consent/client/measurementconsumer",
         "@wfa_measurement_system//src/main/kotlin/org/wfanet/measurement/api/v2alpha:resource_key",
     ],
 )

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
@@ -30,7 +30,7 @@ class CoroutineLauncher(
     scope.launch {
       stepExecutor.execute(
         attemptKey = attemptKey,
-        step = Step.parseFrom(exchangeStep.signedExchangeWorkflow.data)
+        step = Step.parseFrom(exchangeStep.signedExchangeWorkflow.serializedExchangeWorkflow)
       )
     }
   }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncherTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncherTest.kt
@@ -41,7 +41,7 @@ class CoroutineLauncherTest {
       ExchangeStep.newBuilder()
         .apply {
           name = "some-exchange-step-name"
-          signedExchangeWorkflowBuilder.data = workflowStep.toByteString()
+          signedExchangeWorkflowBuilder.serializedExchangeWorkflow = workflowStep.toByteString()
         }
         .build()
 


### PR DESCRIPTION
* Use new function `verifyExchanteStepSignatures()` from
consent-signaling-client to implement validation at
`ExchangeStepValidatorImpl` class

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/121)
<!-- Reviewable:end -->
