### PR TITLE
Update ExchangeTaskExecutor to use the latest proto

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
-import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow.Step
 
 /** Executes an [ExchangeStep] in a new coroutine in [scope]. */
 class CoroutineLauncher(
@@ -27,11 +26,6 @@ class CoroutineLauncher(
   private val stepExecutor: ExchangeStepExecutor
 ) : JobLauncher {
   override suspend fun execute(exchangeStep: ExchangeStep, attemptKey: ExchangeStepAttemptKey) {
-    scope.launch {
-      stepExecutor.execute(
-        attemptKey = attemptKey,
-        step = Step.parseFrom(exchangeStep.signedExchangeWorkflow.serializedExchangeWorkflow)
-      )
-    }
+    scope.launch { stepExecutor.execute(attemptKey = attemptKey, exchangeStep = exchangeStep) }
   }
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepExecutor.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepExecutor.kt
@@ -14,11 +14,12 @@
 
 package org.wfanet.panelmatch.client.launcher
 
+import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
 import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow
 
 /** Executes [ExchangeWorkflow.Step]s. */
 interface ExchangeStepExecutor {
   /** Executes [step]. */
-  suspend fun execute(attemptKey: ExchangeStepAttemptKey, step: ExchangeWorkflow.Step)
+  suspend fun execute(attemptKey: ExchangeStepAttemptKey, exchangeStep: ExchangeStep)
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/testing/TestStep.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/testing/TestStep.kt
@@ -18,7 +18,12 @@ import com.google.protobuf.ByteString
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.wfanet.measurement.api.v2alpha.ExchangeStep
+import org.wfanet.measurement.api.v2alpha.ExchangeStep.SignedExchangeWorkflow
+import org.wfanet.measurement.api.v2alpha.ExchangeStepKt.signedExchangeWorkflow
 import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow
+import org.wfanet.measurement.api.v2alpha.exchangeStep
+import org.wfanet.measurement.api.v2alpha.exchangeWorkflow
 import org.wfanet.panelmatch.common.toByteString
 import org.wfanet.panelmatch.protocol.common.DeterministicCommutativeCipher
 
@@ -66,6 +71,20 @@ fun buildMockCryptor(): DeterministicCommutativeCipher {
   return mockCryptor
 }
 
+fun buildWorkflow(
+  testedStep: ExchangeWorkflow.Step,
+  dataProviderName: String,
+  modelProviderName: String
+): ExchangeWorkflow {
+  return exchangeWorkflow { steps += testedStep }
+}
+
+fun buildSignedExchangeWorkflow(exchangeWorkflow: ExchangeWorkflow): SignedExchangeWorkflow {
+  return signedExchangeWorkflow {
+    this.serializedExchangeWorkflow = exchangeWorkflow.toByteString()
+  }
+}
+
 fun buildStep(
   stepType: ExchangeWorkflow.Step.StepCase,
   privateInputLabels: Map<String, String> = emptyMap(),
@@ -102,4 +121,19 @@ fun buildStep(
       }
     }
     .build()
+}
+
+fun buildExchangeStep(
+  name: String,
+  stepIndex: Int = 0,
+  dataProviderName: String,
+  modelProviderName: String,
+  testedStep: ExchangeWorkflow.Step
+): ExchangeStep {
+  return exchangeStep {
+    this.stepIndex = stepIndex
+    this.name = name
+    this.signedExchangeWorkflow =
+      buildSignedExchangeWorkflow(buildWorkflow(testedStep, dataProviderName, modelProviderName))
+  }
 }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncherTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncherTest.kt
@@ -27,6 +27,7 @@ import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
 import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow
 import org.wfanet.measurement.common.CountDownLatch
 import org.wfanet.panelmatch.client.launcher.testing.buildStep
+import org.wfanet.panelmatch.client.launcher.testing.buildWorkflow
 import org.wfanet.panelmatch.common.testing.runBlockingTest
 
 @RunWith(JUnit4::class)
@@ -37,11 +38,13 @@ class CoroutineLauncherTest {
   @Test
   fun launches() = runBlockingTest {
     val workflowStep = buildStep(ExchangeWorkflow.Step.StepCase.ENCRYPT_STEP)
+    val workflow = buildWorkflow(workflowStep, "some-edp", "some-mp")
     val step =
       ExchangeStep.newBuilder()
         .apply {
+          stepIndex = 0
           name = "some-exchange-step-name"
-          signedExchangeWorkflowBuilder.serializedExchangeWorkflow = workflowStep.toByteString()
+          signedExchangeWorkflowBuilder.serializedExchangeWorkflow = workflow.toByteString()
         }
         .build()
 
@@ -63,6 +66,6 @@ class CoroutineLauncherTest {
     middleLatch.countDown()
     endLatch.await()
 
-    verify(stepExecutor).execute(attemptKey, workflowStep)
+    verify(stepExecutor).execute(attemptKey, step)
   }
 }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutorTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutorTest.kt
@@ -31,6 +31,7 @@ import org.wfanet.measurement.common.asBufferedFlow
 import org.wfanet.measurement.common.flatten
 import org.wfanet.panelmatch.client.exchangetasks.ExchangeTask
 import org.wfanet.panelmatch.client.launcher.testing.FakeTimeout
+import org.wfanet.panelmatch.client.launcher.testing.buildExchangeStep
 import org.wfanet.panelmatch.client.launcher.testing.buildStep
 import org.wfanet.panelmatch.client.storage.VerifiedStorageClient
 import org.wfanet.panelmatch.client.storage.testing.makeTestVerifiedStorageClient
@@ -76,12 +77,18 @@ class ExchangeTaskExecutorTest {
 
     exchangeTaskExecutor.execute(
       ExchangeStepAttemptKey("w", "x", "y", "z"),
-      buildStep(
-        ENCRYPT_STEP,
-        privateInputLabels = mapOf("a" to "b"),
-        sharedInputLabels = mapOf("c" to "d"),
-        privateOutputLabels = mapOf("Out:c" to "e"),
-        sharedOutputLabels = mapOf("Out:a" to "f")
+      buildExchangeStep(
+        name = "some-name",
+        dataProviderName = "some-edp",
+        modelProviderName = "some-mp",
+        testedStep =
+          buildStep(
+            ENCRYPT_STEP,
+            privateInputLabels = mapOf("a" to "b"),
+            sharedInputLabels = mapOf("c" to "d"),
+            privateOutputLabels = mapOf("Out:c" to "e"),
+            sharedOutputLabels = mapOf("Out:a" to "f")
+          )
       )
     )
 
@@ -110,10 +117,16 @@ class ExchangeTaskExecutorTest {
     assertFailsWith<CancellationException> {
       exchangeTaskExecutor.execute(
         ExchangeStepAttemptKey("w", "x", "y", "z"),
-        buildStep(
-          ENCRYPT_STEP,
-          privateInputLabels = mapOf("a" to "b"),
-          sharedOutputLabels = mapOf("Out:a" to "c")
+        buildExchangeStep(
+          name = "some-name",
+          dataProviderName = "some-edp",
+          modelProviderName = "some-mp",
+          testedStep =
+            buildStep(
+              ENCRYPT_STEP,
+              privateInputLabels = mapOf("a" to "b"),
+              sharedOutputLabels = mapOf("Out:a" to "c")
+            )
         )
       )
     }


### PR DESCRIPTION
Now it requires the entire ExchangeStep to run execute()

Fixes bug DE2

Reads the proper Step from the included serialized ExchangeWorkflow

Previously these were using a version of the proto that included the
Step details in ExchangeStep

There's a reasonable place to validate the ExchangeWorkflow in execute() now, as well

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/124)
<!-- Reviewable:end -->
