### PR TITLE
Adds a proto to created a signed index of multipart data

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
-import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow.Step
 
 /** Executes an [ExchangeStep] in a new coroutine in [scope]. */
 class CoroutineLauncher(
@@ -27,11 +26,6 @@ class CoroutineLauncher(
   private val stepExecutor: ExchangeStepExecutor
 ) : JobLauncher {
   override suspend fun execute(exchangeStep: ExchangeStep, attemptKey: ExchangeStepAttemptKey) {
-    scope.launch {
-      stepExecutor.execute(
-        attemptKey = attemptKey,
-        step = Step.parseFrom(exchangeStep.signedExchangeWorkflow.serializedExchangeWorkflow)
-      )
-    }
+    scope.launch { stepExecutor.execute(attemptKey = attemptKey, exchangeStep = exchangeStep) }
   }
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepExecutor.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepExecutor.kt
@@ -14,11 +14,12 @@
 
 package org.wfanet.panelmatch.client.launcher
 
+import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
 import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow
 
 /** Executes [ExchangeWorkflow.Step]s. */
 interface ExchangeStepExecutor {
   /** Executes [step]. */
-  suspend fun execute(attemptKey: ExchangeStepAttemptKey, step: ExchangeWorkflow.Step)
+  suspend fun execute(attemptKey: ExchangeStepAttemptKey, exchangeStep: ExchangeStep)
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutor.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutor.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
+import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttempt
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
 import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow
@@ -48,10 +49,12 @@ class ExchangeTaskExecutor(
    * Reads inputs for [step], executes [step], and writes the outputs to appropriate [StorageClient]
    * .
    */
-  override suspend fun execute(attemptKey: ExchangeStepAttemptKey, step: ExchangeWorkflow.Step) {
+  override suspend fun execute(attemptKey: ExchangeStepAttemptKey, exchangeStep: ExchangeStep) {
     withContext(CoroutineName(attemptKey.exchangeStepAttemptId)) {
       try {
-        tryExecute(attemptKey, step)
+        val workflow =
+          ExchangeWorkflow.parseFrom(exchangeStep.signedExchangeWorkflow.serializedExchangeWorkflow)
+        tryExecute(attemptKey, workflow.getSteps(exchangeStep.stepIndex))
       } catch (e: Exception) {
         logger.addToTaskLog(e.toString())
         markAsFinished(attemptKey, ExchangeStepAttempt.State.FAILED)

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/testing/TestStep.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/testing/TestStep.kt
@@ -18,6 +18,7 @@ import com.google.protobuf.ByteString
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow
 import org.wfanet.panelmatch.common.toByteString
 import org.wfanet.panelmatch.protocol.common.DeterministicCommutativeCipher
@@ -66,6 +67,14 @@ fun buildMockCryptor(): DeterministicCommutativeCipher {
   return mockCryptor
 }
 
+fun buildWorkflow(
+  testedStep: ExchangeWorkflow.Step,
+  edpName: String,
+  mpName: String
+): ExchangeWorkflow {
+  return ExchangeWorkflow.newBuilder().addSteps(testedStep).build()
+}
+
 fun buildStep(
   stepType: ExchangeWorkflow.Step.StepCase,
   privateInputLabels: Map<String, String> = emptyMap(),
@@ -100,6 +109,23 @@ fun buildStep(
               .build()
         else -> error("Unsupported step config")
       }
+    }
+    .build()
+}
+
+fun buildExchangeStep(
+  name: String,
+  stepIndex: Int = 0,
+  edpName: String,
+  mpName: String,
+  testedStep: ExchangeWorkflow.Step
+): ExchangeStep {
+  return ExchangeStep.newBuilder()
+    .apply {
+      stepIndex
+      name
+      signedExchangeWorkflowBuilder.serializedExchangeWorkflow =
+        buildWorkflow(testedStep, edpName, mpName).toByteString()
     }
     .build()
 }

--- a/src/main/proto/wfa/panelmatch/protocol/exchangesteps/exchangesteps.proto
+++ b/src/main/proto/wfa/panelmatch/protocol/exchangesteps/exchangesteps.proto
@@ -24,3 +24,12 @@ option java_multiple_files = true;
 message SharedInputs {
   repeated bytes data = 1;
 }
+
+// A format used for multipart uploads where each part is signed (say serialized
+// as the `data` portion of SignedData). Each piece has an index, so a reader
+// can verify that the proper number of chunks (and no duplicate chunks) are
+// included.
+message MultipartInput {
+  bytes data = 1;
+  int64 chunk_index = 2;
+}

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncherTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncherTest.kt
@@ -27,6 +27,7 @@ import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
 import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow
 import org.wfanet.measurement.common.CountDownLatch
 import org.wfanet.panelmatch.client.launcher.testing.buildStep
+import org.wfanet.panelmatch.client.launcher.testing.buildWorkflow
 import org.wfanet.panelmatch.common.testing.runBlockingTest
 
 @RunWith(JUnit4::class)
@@ -37,11 +38,13 @@ class CoroutineLauncherTest {
   @Test
   fun `launches`() = runBlockingTest {
     val workflowStep = buildStep(ExchangeWorkflow.Step.StepCase.ENCRYPT_STEP)
+    val workflow = buildWorkflow(workflowStep, "some-edp", "some-mp")
     val step =
       ExchangeStep.newBuilder()
         .apply {
+          stepIndex = 0
           name = "some-exchange-step-name"
-          signedExchangeWorkflowBuilder.serializedExchangeWorkflow = workflowStep.toByteString()
+          signedExchangeWorkflowBuilder.serializedExchangeWorkflow = workflow.toByteString()
         }
         .build()
 
@@ -63,6 +66,6 @@ class CoroutineLauncherTest {
     middleLatch.countDown()
     endLatch.await()
 
-    verify(stepExecutor).execute(attemptKey, workflowStep)
+    verify(stepExecutor).execute(attemptKey, step)
   }
 }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutorTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutorTest.kt
@@ -36,6 +36,7 @@ import org.wfanet.measurement.common.crypto.testing.KEY_ALGORITHM
 import org.wfanet.measurement.common.flatten
 import org.wfanet.panelmatch.client.exchangetasks.ExchangeTask
 import org.wfanet.panelmatch.client.launcher.testing.FakeTimeout
+import org.wfanet.panelmatch.client.launcher.testing.buildExchangeStep
 import org.wfanet.panelmatch.client.launcher.testing.buildStep
 import org.wfanet.panelmatch.client.storage.VerifiedStorageClient
 import org.wfanet.panelmatch.client.storage.testing.InMemoryStorageClient
@@ -93,12 +94,18 @@ class ExchangeTaskExecutorTest {
 
     exchangeTaskExecutor.execute(
       ExchangeStepAttemptKey("w", "x", "y", "z"),
-      buildStep(
-        ENCRYPT_STEP,
-        privateInputLabels = mapOf("a" to "b"),
-        sharedInputLabels = mapOf("c" to "d"),
-        privateOutputLabels = mapOf("Out:c" to "e"),
-        sharedOutputLabels = mapOf("Out:a" to "f")
+      buildExchangeStep(
+        name = "some-name",
+        edpName = "some-edp",
+        mpName = "some-mp",
+        testedStep =
+          buildStep(
+            ENCRYPT_STEP,
+            privateInputLabels = mapOf("a" to "b"),
+            sharedInputLabels = mapOf("c" to "d"),
+            privateOutputLabels = mapOf("Out:c" to "e"),
+            sharedOutputLabels = mapOf("Out:a" to "f")
+          )
       )
     )
 
@@ -127,10 +134,16 @@ class ExchangeTaskExecutorTest {
     assertFailsWith<CancellationException> {
       exchangeTaskExecutor.execute(
         ExchangeStepAttemptKey("w", "x", "y", "z"),
-        buildStep(
-          ENCRYPT_STEP,
-          privateInputLabels = mapOf("a" to "b"),
-          sharedOutputLabels = mapOf("Out:a" to "c")
+        buildExchangeStep(
+          name = "some-name",
+          edpName = "some-edp",
+          mpName = "some-mp",
+          testedStep =
+            buildStep(
+              ENCRYPT_STEP,
+              privateInputLabels = mapOf("a" to "b"),
+              sharedOutputLabels = mapOf("Out:a" to "c")
+            )
         )
       )
     }


### PR DESCRIPTION
Things like pcollection are too large to validate at once. This is a
simple wrapper proto that can be used to validate that a selection of
SignedData objects has the correct number of objects and no duplicates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/126)
<!-- Reviewable:end -->
