### PR TITLE
Add step for building private membership queries

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
@@ -14,6 +14,7 @@
 
 package org.wfanet.panelmatch.client.deploy
 
+import java.security.cert.X509Certificate
 import kotlinx.coroutines.runBlocking
 import org.wfanet.measurement.common.logAndSuppressExceptionSuspend
 import org.wfanet.measurement.common.throttler.Throttler
@@ -39,6 +40,12 @@ abstract class ExchangeWorkflowDaemon : Runnable {
   /** Kingdom [ApiClient]. */
   abstract val apiClient: ApiClient
 
+  // TODO derive `localCertificate`
+  abstract val localCertificate: X509Certificate
+
+  // TODO derive `uriPrefix`
+  abstract val uriPrefix: String
+
   /** [VerifiedStorageClient] for writing to local (non-shared) storage. */
   abstract val privateStorage: VerifiedStorageClient
 
@@ -56,7 +63,9 @@ abstract class ExchangeWorkflowDaemon : Runnable {
       ExchangeTaskMapperForJoinKeyExchange(
         getDeterministicCommutativeCryptor = ::JniDeterministicCommutativeCipher,
         getPrivateMembershipCryptor = ::JniPrivateMembershipCryptor,
-        privateStorage = privateStorage
+        localCertificate = localCertificate,
+        privateStorage = privateStorage,
+        uriPrefix = uriPrefix
       )
 
     val stepExecutor =

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonMain.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonMain.kt
@@ -14,6 +14,7 @@
 
 package org.wfanet.panelmatch.client.deploy
 
+import java.security.cert.X509Certificate
 import org.wfanet.measurement.common.commandLineMain
 import org.wfanet.panelmatch.client.storage.VerifiedStorageClient
 import org.wfanet.panelmatch.common.secrets.SecretMap
@@ -34,6 +35,10 @@ private object UnimplementedExchangeWorkflowDaemon : ExchangeWorkflowDaemonFromF
     get() = TODO("Not yet implemented")
   override val privateStorage: VerifiedStorageClient
     get() = TODO("Not yet implemented")
+  override val localCertificate: X509Certificate
+    get() = TODO("Not yet implemented")
+  override val uriPrefix: String
+    get() = TODO("Not yet implemented: coming from client storage")
 
   override val validExchangeWorkflows: SecretMap by lazy {
     approvedWorkflowFlags.approvedExchangeWorkflows

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/BuildPrivateMembershipQueriesTask.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/BuildPrivateMembershipQueriesTask.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.flow.flowOf
 import org.apache.beam.sdk.Pipeline
 import org.apache.beam.sdk.values.PCollection
 import org.apache.beam.sdk.values.PCollectionView
+import org.wfanet.panelmatch.client.logger.addToTaskLog
+import org.wfanet.panelmatch.client.logger.loggerFor
 import org.wfanet.panelmatch.client.privatemembership.CreateQueriesParameters
 import org.wfanet.panelmatch.client.privatemembership.EncryptedQueryBundle
 import org.wfanet.panelmatch.client.privatemembership.PanelistKeyAndJoinKey
@@ -53,6 +55,7 @@ class BuildPrivateMembershipQueriesTask(
   )
 
   override suspend fun execute(input: Map<String, VerifiedBlob>): Map<String, Flow<ByteString>> {
+    logger.addToTaskLog("Executing build private membership queries")
     val pipeline = Pipeline.create()
 
     // TODO: previous steps need to output in this format.
@@ -107,5 +110,9 @@ class BuildPrivateMembershipQueriesTask(
       "query-decryption-keys" to flowOf(queryDecryptionKeysFileSpec.spec.toByteString()),
       "encrypted-queries" to flowOf(encryptedQueriesFileSpec.spec.toByteString())
     )
+  }
+
+  companion object {
+    private val logger by loggerFor()
   }
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskMapperForJoinKeyExchange.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskMapperForJoinKeyExchange.kt
@@ -15,12 +15,14 @@
 package org.wfanet.panelmatch.client.exchangetasks
 
 import com.google.protobuf.ByteString
+import java.security.cert.X509Certificate
 import java.time.Clock
 import java.time.Duration
 import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow
 import org.wfanet.measurement.api.v2alpha.ExchangeWorkflow.Step.StepCase
 import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
 import org.wfanet.measurement.common.throttler.Throttler
+import org.wfanet.panelmatch.client.privatemembership.CreateQueriesParameters
 import org.wfanet.panelmatch.client.privatemembership.PrivateMembershipCryptor
 import org.wfanet.panelmatch.client.storage.VerifiedStorageClient
 import org.wfanet.panelmatch.common.crypto.DeterministicCommutativeCipher
@@ -29,12 +31,17 @@ import org.wfanet.panelmatch.common.crypto.DeterministicCommutativeCipher
 class ExchangeTaskMapperForJoinKeyExchange(
   private val getDeterministicCommutativeCryptor: () -> DeterministicCommutativeCipher,
   private val getPrivateMembershipCryptor: (ByteString) -> PrivateMembershipCryptor,
+  // TODO remove `localCertificate` from constructor
+  private val localCertificate: X509Certificate,
   private val privateStorage: VerifiedStorageClient,
   private val throttler: Throttler =
-    MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(100))
+    MinimumIntervalThrottler(Clock.systemUTC(), Duration.ofMillis(100)),
+  // TODO remove `uriPrefix` from constructor
+  private val uriPrefix: String,
 ) : ExchangeTaskMapper {
 
   override suspend fun getExchangeTaskForStep(step: ExchangeWorkflow.Step): ExchangeTask {
+    // TODO move each step into a separate function
     @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
     return when (step.stepCase) {
       StepCase.ENCRYPT_STEP ->
@@ -58,7 +65,34 @@ class ExchangeTaskMapperForJoinKeyExchange(
       }
       StepCase.GENERATE_CERTIFICATE_STEP -> TODO()
       StepCase.EXECUTE_PRIVATE_MEMBERSHIP_QUERIES_STEP -> TODO()
-      StepCase.BUILD_PRIVATE_MEMBERSHIP_QUERIES_STEP -> TODO()
+      StepCase.BUILD_PRIVATE_MEMBERSHIP_QUERIES_STEP -> {
+        val privateMembershipCryptor =
+          getPrivateMembershipCryptor(step.buildPrivateMembershipQueriesStep.serializedParameters)
+        val outputs =
+          BuildPrivateMembershipQueriesTask.Outputs(
+            encryptedQueriesFileCount =
+              step.buildPrivateMembershipQueriesStep.encryptedQueryBundleFileCount,
+            encryptedQueriesFileName = step.outputLabelsMap.getValue("encrypted-queries"),
+            queryIdAndPanelistKeyFileCount =
+              step.buildPrivateMembershipQueriesStep.queryIdAndPanelistKeyFileCount,
+            queryIdAndPanelistKeyFileName = step.outputLabelsMap.getValue("query-decryption-keys"),
+          )
+        BuildPrivateMembershipQueriesTask(
+          localCertificate = localCertificate,
+          outputs = outputs,
+          parameters =
+            CreateQueriesParameters(
+              numShards = step.buildPrivateMembershipQueriesStep.numShards,
+              numBucketsPerShard = step.buildPrivateMembershipQueriesStep.numBucketsPerShard,
+              maxQueriesPerShard = step.buildPrivateMembershipQueriesStep.numQueriesPerShard,
+              // TODO get `padQueries` from new field at step.buildPrivateMembershipQueriesStep
+              padQueries = true,
+            ),
+          privateKey = privateStorage.privateKey,
+          privateMembershipCryptor = privateMembershipCryptor,
+          uriPrefix = uriPrefix,
+        )
+      }
       StepCase.DECRYPT_PRIVATE_MEMBERSHIP_QUERY_RESULTS_STEP -> TODO()
       StepCase.COPY_FROM_SHARED_STORAGE_STEP -> TODO()
       StepCase.COPY_TO_SHARED_STORAGE_STEP -> TODO()

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/Storage.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/Storage.kt
@@ -35,7 +35,7 @@ class VerifiedStorageClient(
   private val storageClient: StorageClient,
   private val readCert: X509Certificate,
   private val writeCert: X509Certificate,
-  private val privateKey: PrivateKey
+  val privateKey: PrivateKey
 ) {
 
   val defaultBufferSizeBytes: Int = storageClient.defaultBufferSizeBytes

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskMapperForJoinKeyExchangeTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskMapperForJoinKeyExchangeTest.kt
@@ -20,6 +20,8 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.api.v2alpha.ExchangeWorkflowKt.StepKt.encryptStep
 import org.wfanet.measurement.api.v2alpha.ExchangeWorkflowKt.step
+import org.wfanet.measurement.common.crypto.readCertificate
+import org.wfanet.measurement.common.crypto.testing.FIXED_SERVER_CERT_PEM_FILE
 import org.wfanet.panelmatch.client.launcher.testing.inputStep
 import org.wfanet.panelmatch.client.privatemembership.testing.PlaintextPrivateMembershipCryptor
 import org.wfanet.panelmatch.client.storage.testing.makeTestVerifiedStorageClient
@@ -29,12 +31,16 @@ import org.wfanet.panelmatch.common.testing.runBlockingTest
 @RunWith(JUnit4::class)
 class ExchangeTaskMapperForJoinKeyExchangeTest {
   private val privateStorage = makeTestVerifiedStorageClient()
+  private val sharedStorage = makeTestVerifiedStorageClient()
+  private val localCertificate = readCertificate(FIXED_SERVER_CERT_PEM_FILE)
 
   private val exchangeTaskMapper =
     ExchangeTaskMapperForJoinKeyExchange(
       getDeterministicCommutativeCryptor = ::FakeDeterministicCommutativeCipher,
       getPrivateMembershipCryptor = ::PlaintextPrivateMembershipCryptor,
-      privateStorage = privateStorage
+      localCertificate = localCertificate,
+      privateStorage = privateStorage,
+      uriPrefix = "jk-prefix"
     )
 
   @Test


### PR DESCRIPTION
* Connecting the step to `BuildPrivateMembershipQueriesTask`
* 3 new variables needs to be passed down to `ApacheBeamTask` common task implementation:
  * `localCertificate` (from constructor)
  * `privateKey` (exposed from `VerifiedStorageClient`)
  * `uriPrefix` (should come from the storage client in another PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/151)
<!-- Reviewable:end -->
