### PR TITLE
Make `ExchangeTaskMapperForJoinKeyExchange` abstract

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
@@ -17,19 +17,15 @@ package org.wfanet.panelmatch.client.deploy
 import kotlinx.coroutines.runBlocking
 import org.wfanet.measurement.common.logAndSuppressExceptionSuspend
 import org.wfanet.measurement.common.throttler.Throttler
-import org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskMapperForJoinKeyExchange
+import org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskMapper
 import org.wfanet.panelmatch.client.launcher.ApiClient
 import org.wfanet.panelmatch.client.launcher.CoroutineLauncher
 import org.wfanet.panelmatch.client.launcher.ExchangeStepLauncher
 import org.wfanet.panelmatch.client.launcher.ExchangeStepValidator
 import org.wfanet.panelmatch.client.launcher.ExchangeTaskExecutor
 import org.wfanet.panelmatch.client.launcher.Identity
-import org.wfanet.panelmatch.client.privatemembership.JniPrivateMembershipCryptor
-import org.wfanet.panelmatch.client.privatemembership.JniQueryResultsDecryptor
 import org.wfanet.panelmatch.client.storage.StorageFactory
 import org.wfanet.panelmatch.common.Timeout
-import org.wfanet.panelmatch.common.compression.BrotliCompressorFactory
-import org.wfanet.panelmatch.common.crypto.JniDeterministicCommutativeCipher
 import org.wfanet.panelmatch.common.secrets.SecretMap
 
 /** Runs ExchangeWorkflows. */
@@ -53,16 +49,10 @@ abstract class ExchangeWorkflowDaemon : Runnable {
   /** How long a task should be allowed to run for before being cancelled. */
   abstract val taskTimeout: Timeout
 
+  /** [ExchangeTaskMapper] to create a task based on the step */
+  abstract val exchangeTaskMapper: ExchangeTaskMapper
+
   override fun run() {
-    val exchangeTaskMapper =
-      ExchangeTaskMapperForJoinKeyExchange(
-        compressorFactory = BrotliCompressorFactory(),
-        getDeterministicCommutativeCryptor = ::JniDeterministicCommutativeCipher,
-        getPrivateMembershipCryptor = ::JniPrivateMembershipCryptor,
-        getQueryResultsDecryptor = ::JniQueryResultsDecryptor,
-        privateStorage = privateStorageFactory,
-        inputTaskThrottler = throttler
-      )
 
     val stepExecutor =
       ExchangeTaskExecutor(

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonFromFlags.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonFromFlags.kt
@@ -22,6 +22,7 @@ import org.wfanet.measurement.common.grpc.buildMutualTlsChannel
 import org.wfanet.measurement.common.grpc.withShutdownTimeout
 import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
 import org.wfanet.measurement.common.throttler.Throttler
+import org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskMapper
 import org.wfanet.panelmatch.client.launcher.ApiClient
 import org.wfanet.panelmatch.client.launcher.GrpcApiClient
 import org.wfanet.panelmatch.client.launcher.Identity
@@ -38,6 +39,13 @@ abstract class ExchangeWorkflowDaemonFromFlags : ExchangeWorkflowDaemon() {
 
   /** [VerifiedStorageClient] for payloads to be shared with the other party. */
   abstract val sharedStorage: VerifiedStorageClient
+
+  override val exchangeTaskMapper: ExchangeTaskMapper by lazy {
+    ProductionExchangeTaskMapper(
+      privateStorage = privateStorageFactory,
+      inputTaskThrottler = throttler,
+    )
+  }
 
   override val apiClient: ApiClient by lazy {
     val clientCerts =

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ProductionExchangeTaskMapper.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ProductionExchangeTaskMapper.kt
@@ -1,0 +1,33 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.deploy
+
+import org.wfanet.measurement.common.throttler.Throttler
+import org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskMapperForJoinKeyExchange
+import org.wfanet.panelmatch.client.privatemembership.JniPrivateMembershipCryptor
+import org.wfanet.panelmatch.client.privatemembership.JniQueryResultsDecryptor
+import org.wfanet.panelmatch.client.storage.StorageFactory
+import org.wfanet.panelmatch.common.compression.BrotliCompressorFactory
+import org.wfanet.panelmatch.common.crypto.JniDeterministicCommutativeCipher
+
+class ProductionExchangeTaskMapper(
+  override val privateStorage: StorageFactory,
+  override val inputTaskThrottler: Throttler,
+) : ExchangeTaskMapperForJoinKeyExchange() {
+  override val compressorFactory by lazy { BrotliCompressorFactory() }
+  override val deterministicCommutativeCryptor by lazy { JniDeterministicCommutativeCipher() }
+  override val getPrivateMembershipCryptor = ::JniPrivateMembershipCryptor
+  override val queryResultsDecryptor by lazy { JniQueryResultsDecryptor() }
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/common/compression/NoOpCompressorFactory.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/compression/NoOpCompressorFactory.kt
@@ -15,7 +15,7 @@
 package org.wfanet.panelmatch.common.compression
 
 /** WARNING: since this does no compression, you likely do not want to use it in production. */
-class NoOpCompressorFactory : CompressorFactory() {
+object NoOpCompressorFactory : CompressorFactory() {
   override fun build(dictionary: Dictionary): Compressor {
     return NoOpCompressor()
   }

--- a/src/main/kotlin/org/wfanet/panelmatch/common/compression/UncompressedDictionaryBuilder.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/compression/UncompressedDictionaryBuilder.kt
@@ -24,7 +24,7 @@ import com.google.protobuf.ByteString
 class UncompressedDictionaryBuilder : DictionaryBuilder {
   override val preferredSampleSize: Int = 0
 
-  override val factory: CompressorFactory = NoOpCompressorFactory()
+  override val factory: CompressorFactory = NoOpCompressorFactory
 
   override fun buildDictionary(eventsSample: Iterable<ByteString>): Dictionary {
     return dictionary {}

--- a/src/main/kotlin/org/wfanet/panelmatch/common/crypto/testing/FakeDeterministicCommuativeCipher.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/crypto/testing/FakeDeterministicCommuativeCipher.kt
@@ -21,7 +21,8 @@ import org.wfanet.panelmatch.common.toByteString
 private const val SEPARATOR = " encrypted by "
 
 /** For testing only. Does not play nicely with non-Utf8 source data. */
-class FakeDeterministicCommutativeCipher : DeterministicCommutativeCipher {
+object FakeDeterministicCommutativeCipher : DeterministicCommutativeCipher {
+  val INVALID_KEY = "invalid key".toByteString()
 
   override fun generateKey(): ByteString {
     var key = ""
@@ -52,9 +53,5 @@ class FakeDeterministicCommutativeCipher : DeterministicCommutativeCipher {
       require(dataString.contains(encryptionString)) { "invalid ciphertext" }
       dataString.replace(encryptionString, "").toByteString()
     }
-  }
-
-  companion object {
-    val INVALID_KEY = "invalid key".toByteString()
   }
 }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/DeterministicCommutativeCryptorExchangeTaskTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/DeterministicCommutativeCryptorExchangeTaskTest.kt
@@ -39,15 +39,14 @@ private const val ATTEMPT_KEY = "some-arbitrary-attempt-key"
 @RunWith(JUnit4::class)
 class DeterministicCommutativeCryptorExchangeTaskTest {
   private val mockStorage = InMemoryStorageClient()
-  private val deterministicCommutativeCryptor = FakeDeterministicCommutativeCipher()
-  private val mpSecretKey = FakeDeterministicCommutativeCipher().generateKey()
-  private val dpSecretKey = FakeDeterministicCommutativeCipher().generateKey()
-  private val singleBlindedKeys =
-    FakeDeterministicCommutativeCipher().encrypt(mpSecretKey, JOIN_KEYS)
+  private val deterministicCommutativeCryptor = FakeDeterministicCommutativeCipher
+  private val mpSecretKey = FakeDeterministicCommutativeCipher.generateKey()
+  private val dpSecretKey = FakeDeterministicCommutativeCipher.generateKey()
+  private val singleBlindedKeys = FakeDeterministicCommutativeCipher.encrypt(mpSecretKey, JOIN_KEYS)
   private val doubleBlindedKeys =
-    FakeDeterministicCommutativeCipher().reEncrypt(dpSecretKey, singleBlindedKeys)
+    FakeDeterministicCommutativeCipher.reEncrypt(dpSecretKey, singleBlindedKeys)
   private val lookupKeys =
-    FakeDeterministicCommutativeCipher().decrypt(mpSecretKey, doubleBlindedKeys)
+    FakeDeterministicCommutativeCipher.decrypt(mpSecretKey, doubleBlindedKeys)
   private val invalidKey = FakeDeterministicCommutativeCipher.INVALID_KEY
   val hashedJoinKeysAndIds = buildJoinKeysAndIds(JOIN_KEYS)
   val singleBlindedKeysAndIds = buildJoinKeysAndIds(singleBlindedKeys)

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/GenerateSymmetricKeyTaskTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/GenerateSymmetricKeyTaskTest.kt
@@ -29,7 +29,7 @@ private const val ATTEMPT_KEY = "some-arbitrary-attempt-key"
 
 @RunWith(JUnit4::class)
 class GenerateSymmetricKeyTaskTest {
-  private val deterministicCommutativeCryptor = FakeDeterministicCommutativeCipher()
+  private val deterministicCommutativeCryptor = FakeDeterministicCommutativeCipher
 
   @Test
   fun `generate key 2x yields different keys`() = withTestContext {

--- a/src/test/kotlin/org/wfanet/panelmatch/common/crypto/testing/FakeDeterministicCommutativeCipherTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/common/crypto/testing/FakeDeterministicCommutativeCipherTest.kt
@@ -21,7 +21,7 @@ import org.wfanet.panelmatch.common.crypto.DeterministicCommutativeCipher
 
 @RunWith(JUnit4::class)
 class FakeDeterministicCommutativeCipherTest : AbstractDeterministicCommutativeCipherTest() {
-  override val cipher: DeterministicCommutativeCipher = FakeDeterministicCommutativeCipher()
+  override val cipher: DeterministicCommutativeCipher = FakeDeterministicCommutativeCipher
   override val invalidKey: ByteString = FakeDeterministicCommutativeCipher.INVALID_KEY
   override val privateKey1 = cipher.generateKey()
   override val privateKey2 = cipher.generateKey()


### PR DESCRIPTION
Per TODO make `ExchangeTaskMapperForJoinKeyExchange` abstract, also
* Hoist its dependencies to ` ExchangeWorkflowDaemonFromFlags` and make them `lazy`
* Make class implementations for testing be singletons if they don' t have constructor params: `NoOpCompressorFactory` and `FakeDeterministicCommutativeCipher` (to keep in line with `AlwaysReadyThrottler`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/169)
<!-- Reviewable:end -->
