### PR TITLE
Update ExchangeWorkflowDaemon to build storage selectors

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemon.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.wfanet.measurement.common.logAndSuppressExceptionSuspend
 import org.wfanet.measurement.common.throttler.Throttler
+import org.wfanet.panelmatch.client.common.ExchangeContext
 import org.wfanet.panelmatch.client.common.Identity
 import org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskMapper
 import org.wfanet.panelmatch.client.launcher.ApiClient
@@ -29,6 +30,8 @@ import org.wfanet.panelmatch.client.launcher.ExchangeStepValidatorImpl
 import org.wfanet.panelmatch.client.launcher.ExchangeTaskExecutor
 import org.wfanet.panelmatch.client.storage.PrivateStorageSelector
 import org.wfanet.panelmatch.client.storage.SharedStorageSelector
+import org.wfanet.panelmatch.client.storage.StorageDetails
+import org.wfanet.panelmatch.client.storage.StorageFactory
 import org.wfanet.panelmatch.common.Timeout
 import org.wfanet.panelmatch.common.certificates.CertificateManager
 import org.wfanet.panelmatch.common.secrets.SecretMap
@@ -42,11 +45,39 @@ abstract class ExchangeWorkflowDaemon : Runnable {
   /** Kingdom [ApiClient]. */
   abstract val apiClient: ApiClient
 
+  /** [SecretMap] used as an interface to retrieve root certificates */
+  abstract val rootCertificates: SecretMap
+
+  /**
+   * [SecretMap] used as an interface to retrieve private keys associated with exchange certificates
+   */
+  abstract val privateKeys: SecretMap
+
   /** [PrivateStorageSelector] for writing to local (non-shared) storage. */
   abstract val privateStorageSelector: PrivateStorageSelector
 
+  /** Map of supported private storage platforms to their respective [StorageFactory] classes */
+  abstract val privateStorageFactories:
+    Map<StorageDetails.PlatformCase, ExchangeContext.(StorageDetails) -> StorageFactory>
+
+  /**
+   * [SecretMap] used as an interface with to the location where all recurring exchanges' private
+   * storage connection information is stored.
+   */
+  abstract val privateStorageInformation: SecretMap
+
   /** [SharedStorageSelector] for writing to shared storage. */
   abstract val sharedStorageSelector: SharedStorageSelector
+
+  /** Map of supported shared storage platforms to their respective [StorageFactory] classes */
+  abstract val sharedStorageFactories:
+    Map<StorageDetails.PlatformCase, ExchangeContext.(StorageDetails) -> StorageFactory>
+
+  /**
+   * [SecretMap] used as an interface with to the location where all recurring exchanges' shared
+   * storage connection information is stored.
+   */
+  abstract val sharedStorageInformation: SecretMap
 
   /**
    * [CertificateManager] for managing access to the certificate API service and private

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonFromFlags.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonFromFlags.kt
@@ -38,7 +38,6 @@ abstract class ExchangeWorkflowDaemonFromFlags : ExchangeWorkflowDaemon() {
   protected lateinit var flags: ExchangeWorkflowFlags
     private set
 
-  // TODO(jonmolle): Implement certificateManager and the storage SecretMaps here.
   override val exchangeTaskMapper: ExchangeTaskMapper by lazy {
     ProductionExchangeTaskMapper(
       inputTaskThrottler = throttler,

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonMain.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowDaemonMain.kt
@@ -16,10 +16,10 @@ package org.wfanet.panelmatch.client.deploy
 
 import java.time.Clock
 import org.wfanet.measurement.common.commandLineMain
-import org.wfanet.panelmatch.client.storage.PrivateStorageSelector
-import org.wfanet.panelmatch.client.storage.SharedStorageSelector
+import org.wfanet.panelmatch.client.common.ExchangeContext
+import org.wfanet.panelmatch.client.storage.StorageDetails
+import org.wfanet.panelmatch.client.storage.StorageFactory
 import org.wfanet.panelmatch.client.storage.VerifiedStorageClient
-import org.wfanet.panelmatch.common.certificates.CertificateManager
 import org.wfanet.panelmatch.common.secrets.SecretMap
 import picocli.CommandLine
 
@@ -34,13 +34,33 @@ private object UnimplementedExchangeWorkflowDaemon : ExchangeWorkflowDaemonFromF
   lateinit var approvedWorkflowFlags: PlaintextApprovedWorkflowFileFlags
     private set
 
-  override val certificateManager: CertificateManager
+  // TODO: All SecretMaps should be implemented with a static storageClient- or KMS-backed SecretMap
+  //  based on flags. To start this should support our existing StorageFactory implementations
+  //  and call a helper function to choose based on storage details (similar to
+  //  privateStorageSelector, which we unfortunately can't use here as it depends on some of these.)
+  override val privateKeys: SecretMap
     get() = TODO("Not yet implemented")
 
-  override val privateStorageSelector: PrivateStorageSelector
+  override val rootCertificates: SecretMap
     get() = TODO("Not yet implemented")
 
-  override val sharedStorageSelector: SharedStorageSelector
+  override val privateStorageInformation: SecretMap
+    get() = TODO("Not yet implemented")
+
+  override val sharedStorageInformation: SecretMap
+    get() = TODO("Not yet implemented")
+
+  // TODO: set up some default supported factories.
+  // This is the most likely piece of storage to be customized, as it gives a party control over
+  // what StorageClient types they actually support for shared and private storage. That's the main
+  // reason it has been pushed all the way out here for implementation: we expect most custom main
+  // file implementations to want to specify these.
+  override val privateStorageFactories:
+    Map<StorageDetails.PlatformCase, ExchangeContext.(StorageDetails) -> StorageFactory>
+    get() = TODO("Not yet implemented")
+
+  override val sharedStorageFactories:
+    Map<StorageDetails.PlatformCase, ExchangeContext.(StorageDetails) -> StorageFactory>
     get() = TODO("Not yet implemented")
 
   override val clock: Clock = Clock.systemUTC()

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowFlags.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/ExchangeWorkflowFlags.kt
@@ -49,6 +49,15 @@ class ExchangeWorkflowFlags {
     private set
 
   @CommandLine.Option(
+    names = ["--storage-signing-algorithm"],
+    defaultValue = "EC",
+    description = ["The algorithm used in signing data written to shaerd storage."],
+    required = true
+  )
+  lateinit var certAlgorithm: String
+    private set
+
+  @CommandLine.Option(
     names = ["--polling-interval"],
     defaultValue = "1m",
     description = ["How long to sleep between finding and running an ExchangeStep."],

--- a/src/test/kotlin/org/wfanet/panelmatch/integration/ExchangeWorkflowDaemonForTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/integration/ExchangeWorkflowDaemonForTest.kt
@@ -29,6 +29,7 @@ import org.wfanet.measurement.common.grpc.failGrpc
 import org.wfanet.measurement.common.identity.withPrincipalName
 import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
 import org.wfanet.measurement.common.throttler.Throttler
+import org.wfanet.panelmatch.client.common.ExchangeContext
 import org.wfanet.panelmatch.client.common.Identity
 import org.wfanet.panelmatch.client.deploy.ExchangeWorkflowDaemon
 import org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskMapper
@@ -36,6 +37,8 @@ import org.wfanet.panelmatch.client.launcher.ApiClient
 import org.wfanet.panelmatch.client.launcher.GrpcApiClient
 import org.wfanet.panelmatch.client.storage.PrivateStorageSelector
 import org.wfanet.panelmatch.client.storage.SharedStorageSelector
+import org.wfanet.panelmatch.client.storage.StorageDetails
+import org.wfanet.panelmatch.client.storage.StorageFactory
 import org.wfanet.panelmatch.common.Timeout
 import org.wfanet.panelmatch.common.asTimeout
 import org.wfanet.panelmatch.common.certificates.CertificateManager
@@ -53,6 +56,14 @@ class ExchangeWorkflowDaemonForTest(
   private val providerKey: ResourceKey,
   private val taskTimeoutDuration: Duration,
   private val pollingInterval: Duration,
+  override val rootCertificates: SecretMap,
+  override val privateKeys: SecretMap,
+  override val privateStorageFactories:
+    Map<StorageDetails.PlatformCase, ExchangeContext.(StorageDetails) -> StorageFactory>,
+  override val privateStorageInformation: SecretMap,
+  override val sharedStorageFactories:
+    Map<StorageDetails.PlatformCase, ExchangeContext.(StorageDetails) -> StorageFactory>,
+  override val sharedStorageInformation: SecretMap,
 ) : ExchangeWorkflowDaemon() {
 
   override val certificateManager: CertificateManager by lazy { TestCertificateManager() }

--- a/src/test/kotlin/org/wfanet/panelmatch/integration/InProcessPanelMatchIntegrationTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/integration/InProcessPanelMatchIntegrationTest.kt
@@ -133,6 +133,12 @@ class InProcessPanelMatchIntegrationTest {
         providerKey = dataProviderKey,
         taskTimeoutDuration = TASK_TIMEOUT_DURATION,
         pollingInterval = POLLING_INTERVAL,
+        rootCertificates = secretMap,
+        privateKeys = secretMap,
+        privateStorageFactories = emptyMap(),
+        privateStorageInformation = secretMap,
+        sharedStorageFactories = emptyMap(),
+        sharedStorageInformation = secretMap,
       )
 
     val mpScope = createScope("MP SCOPE")
@@ -147,6 +153,12 @@ class InProcessPanelMatchIntegrationTest {
         providerKey = modelProviderKey,
         taskTimeoutDuration = TASK_TIMEOUT_DURATION,
         pollingInterval = POLLING_INTERVAL,
+        rootCertificates = secretMap,
+        privateKeys = secretMap,
+        privateStorageFactories = emptyMap(),
+        privateStorageInformation = secretMap,
+        sharedStorageFactories = emptyMap(),
+        sharedStorageInformation = secretMap,
       )
     edpDaemon.run()
     mpDaemon.run()


### PR DESCRIPTION
Previously we were hard-coding storage clients. Now that we're using storage selectors, we need to take in a bunch of secret maps (and custom Map maps of allowable factories) to build the storage system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/194)
<!-- Reviewable:end -->
