### PR TITLE
Move key generation into CertificateAuthority

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepValidatorImpl.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepValidatorImpl.kt
@@ -41,9 +41,9 @@ class ExchangeStepValidatorImpl(
       )
     }
 
-    @Suppress("BlockingMethodInNonBlockingContext") // Proto parsing is lightweight
     val workflow =
       try {
+        @Suppress("BlockingMethodInNonBlockingContext") // This is in-memory.
         ExchangeWorkflow.parseFrom(serializedExchangeWorkflow)
       } catch (e: InvalidProtocolBufferException) {
         throw InvalidExchangeStepException(

--- a/src/main/kotlin/org/wfanet/panelmatch/client/privatemembership/WriteShardedData.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/privatemembership/WriteShardedData.kt
@@ -85,7 +85,8 @@ private class WriteFilesFn<T : MessageLite>(
     val outputStream = ByteArrayOutputStream()
     val messageFlow = flow {
       for (message in context.element().value) {
-        @Suppress("BlockingMethodInNonBlockingContext") message.writeDelimitedTo(outputStream)
+        @Suppress("BlockingMethodInNonBlockingContext") // This is in-memory.
+        message.writeDelimitedTo(outputStream)
 
         emit(outputStream.toByteArray().toByteString())
         outputStream.reset()

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/PrivateStorageSelector.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/PrivateStorageSelector.kt
@@ -63,7 +63,7 @@ class PrivateStorageSelector(
       privateStorageInfo.get(recurringExchangeId)
         ?: throw StorageNotFoundException("Private storage for exchange $recurringExchangeId")
 
-    @Suppress("BlockingMethodInNonBlockingContext")
+    @Suppress("BlockingMethodInNonBlockingContext") // This is in-memory.
     val storageDetails = StorageDetails.parseFrom(serializedStorageDetails)
 
     require(storageDetails.visibility == StorageDetails.Visibility.PRIVATE)

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/SharedStorageSelector.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/SharedStorageSelector.kt
@@ -69,7 +69,7 @@ class SharedStorageSelector(
       sharedStorageInfo.get(recurringExchangeId)
         ?: throw StorageNotFoundException("Shared storage for exchange $recurringExchangeId")
 
-    @Suppress("BlockingMethodInNonBlockingContext")
+    @Suppress("BlockingMethodInNonBlockingContext") // This is in-memory.
     val storageDetails = StorageDetails.parseFrom(serializedStorageDetails)
 
     require(storageDetails.visibility == StorageDetails.Visibility.SHARED)

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/VerifiedStorageClient.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/VerifiedStorageClient.kt
@@ -71,7 +71,7 @@ class VerifiedStorageClient(
         ?: throw StorageNotFoundException(getSigPath(blobKey))
     val serializedSignature = signatureBlob.toByteString()
 
-    @Suppress("BlockingMethodInNonBlockingContext")
+    @Suppress("BlockingMethodInNonBlockingContext") // This is in-memory.
     return NamedSignature.parseFrom(serializedSignature)
   }
 

--- a/src/main/kotlin/org/wfanet/panelmatch/common/certificates/CertificateAuthority.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/certificates/CertificateAuthority.kt
@@ -14,15 +14,19 @@
 
 package org.wfanet.panelmatch.common.certificates
 
+import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.cert.X509Certificate
 
 /** Creates X509Certificates signed by a protected, root private key. */
 interface CertificateAuthority {
 
-  /** Creates an [X509Certificate] from [publicKey]. */
-  suspend fun makeX509Certificate(
-    publicKey: PublicKey,
-    subjectKeyIdentifier: String
-  ): X509Certificate
+  /**
+   * Creates a [PrivateKey] and corresponding [X509Certificate] signed by [rootPublicKey].
+   *
+   * TODO(@efoxepstein): use SigningKeyHandle instead of a PrivateKey directly.
+   */
+  suspend fun generateX509CertificateAndPrivateKey(
+    rootPublicKey: PublicKey
+  ): Pair<X509Certificate, PrivateKey>
 }


### PR DESCRIPTION
This enables simplifications like using CAs that generate key pairs for you.

https://rally1.rallydev.com/#/?detail=/userstory/613928346229&fdp=true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/201)
<!-- Reviewable:end -->
