### PR TITLE
Key task logs by new TaskLog CoroutineContext element.

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
@@ -14,6 +14,7 @@
 
 package org.wfanet.panelmatch.client.launcher
 
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -27,6 +28,6 @@ class CoroutineLauncher(
   private val stepExecutor: ExchangeStepExecutor
 ) : JobLauncher {
   override suspend fun execute(step: ValidatedExchangeStep, attemptKey: ExchangeStepAttemptKey) {
-    scope.launch { stepExecutor.execute(step, attemptKey) }
+    scope.launch(CoroutineName(attemptKey.toName())) { stepExecutor.execute(step, attemptKey) }
   }
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutor.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutor.kt
@@ -16,7 +16,6 @@ package org.wfanet.panelmatch.client.launcher
 
 import com.google.protobuf.ByteString
 import java.util.logging.Level
-import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttempt
@@ -29,6 +28,7 @@ import org.wfanet.panelmatch.client.exchangetasks.CustomIOExchangeTask
 import org.wfanet.panelmatch.client.exchangetasks.ExchangeTask
 import org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskMapper
 import org.wfanet.panelmatch.client.launcher.ExchangeStepValidator.ValidatedExchangeStep
+import org.wfanet.panelmatch.client.logger.TaskLog
 import org.wfanet.panelmatch.client.logger.addToTaskLog
 import org.wfanet.panelmatch.client.logger.getAndClearTaskLog
 import org.wfanet.panelmatch.client.storage.PrivateStorageSelector
@@ -50,7 +50,7 @@ class ExchangeTaskExecutor(
 ) : ExchangeStepExecutor {
 
   override suspend fun execute(step: ValidatedExchangeStep, attemptKey: ExchangeStepAttemptKey) {
-    withContext(CoroutineName(attemptKey.toName())) {
+    withContext(TaskLog(attemptKey.toName())) {
       val context = ExchangeContext(attemptKey, step.date, step.workflow, step.step)
       try {
         context.tryExecute()

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/DeterministicCommutativeCryptorExchangeTaskTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/DeterministicCommutativeCryptorExchangeTaskTest.kt
@@ -18,16 +18,15 @@ import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.ByteString
 import com.google.protobuf.kotlin.toByteStringUtf8
 import kotlin.test.assertFailsWith
-import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.flatten
 import org.wfanet.measurement.storage.testing.InMemoryStorageClient
 import org.wfanet.panelmatch.client.launcher.testing.JOIN_KEYS
+import org.wfanet.panelmatch.client.logger.TaskLog
 import org.wfanet.panelmatch.common.crypto.testing.FakeDeterministicCommutativeCipher
 import org.wfanet.panelmatch.common.storage.createBlob
 
@@ -184,7 +183,7 @@ class DeterministicCommutativeCryptorExchangeTaskTest {
 }
 
 private fun withTestContext(block: suspend () -> Unit) {
-  runBlocking { withContext(CoroutineName(ATTEMPT_KEY) + Dispatchers.Default) { block() } }
+  runBlocking(TaskLog(ATTEMPT_KEY) + Dispatchers.Default) { block() }
 }
 
 private fun buildJoinKeysAndIds(joinKeys: List<ByteString>): List<JoinKeyAndId> {

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/GenerateAsymmetricKeysTaskTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/GenerateAsymmetricKeysTaskTest.kt
@@ -16,14 +16,13 @@ package org.wfanet.panelmatch.client.exchangetasks
 
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.kotlin.toByteStringUtf8
-import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.flatten
+import org.wfanet.panelmatch.client.logger.TaskLog
 import org.wfanet.panelmatch.client.privatemembership.testing.PlaintextPrivateMembershipCryptor
 
 private const val ATTEMPT_KEY = "some-arbitrary-attempt-key"
@@ -45,5 +44,5 @@ class GenerateAsymmetricKeysTaskTest {
 }
 
 private fun withTestContext(block: suspend () -> Unit) {
-  runBlocking { withContext(CoroutineName(ATTEMPT_KEY) + Dispatchers.Default) { block() } }
+  runBlocking(TaskLog(ATTEMPT_KEY) + Dispatchers.Default) { block() }
 }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/GenerateSymmetricKeyTaskTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/GenerateSymmetricKeyTaskTest.kt
@@ -15,16 +15,16 @@
 package org.wfanet.panelmatch.client.exchangetasks
 
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.wfanet.measurement.common.flatten
+import org.wfanet.panelmatch.client.logger.TaskLog
 import org.wfanet.panelmatch.common.crypto.testing.FakeDeterministicCommutativeCipher
 
+private const val LABEL = "symmetric-key"
 private const val ATTEMPT_KEY = "some-arbitrary-attempt-key"
 
 @RunWith(JUnit4::class)
@@ -42,10 +42,13 @@ class GenerateSymmetricKeyTaskTest {
         .execute(emptyMap())
         .mapValues { it.value.flatten() }
 
-    assertThat(result1.getValue("symmetric-key")).isNotEqualTo(result2.getValue("symmetric-key"))
+    assertThat(result1.keys).containsExactly(LABEL)
+    assertThat(result2.keys).containsExactly(LABEL)
+
+    assertThat(result1.getValue(LABEL)).isNotEqualTo(result2.getValue(LABEL))
   }
 }
 
 private fun withTestContext(block: suspend () -> Unit) {
-  runBlocking { withContext(CoroutineName(ATTEMPT_KEY) + Dispatchers.Default) { block() } }
+  runBlocking(TaskLog(ATTEMPT_KEY) + Dispatchers.Default) { block() }
 }


### PR DESCRIPTION
Previous, the coroutine name was used as the key. This was a bit of an
abuse of this because it means that we can't rename coroutines (for
debugging) within an ExchangeTask.

This also stores the logs itself in the CoroutineContext, so we do not
need to keep around a ConcurrentHashMap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/219)
<!-- Reviewable:end -->
