### PR TITLE
Fix logic bug in EventDataPreprocessor.

### DIFF
--- a/src/main/cc/wfa/panelmatch/client/eventpreprocessing/preprocess_events.cc
+++ b/src/main/cc/wfa/panelmatch/client/eventpreprocessing/preprocess_events.cc
@@ -84,6 +84,9 @@ absl::StatusOr<PreprocessEventsResponse> PreprocessEvents(
   PreprocessEventsResponse processed;
   for (const PreprocessEventsRequest::UnprocessedEvent& u :
        request.unprocessed_events()) {
+    if (u.id().empty()) {
+      return absl::InvalidArgumentError("UnprocessedEvent.id is empty");
+    }
     ASSIGN_OR_RETURN(std::string compressed_data,
                      compressor->Compress(u.data()));
     ASSIGN_OR_RETURN(ProcessedData data,

--- a/src/main/cc/wfa/panelmatch/protocol/crypto/event_data_preprocessor.cc
+++ b/src/main/cc/wfa/panelmatch/protocol/crypto/event_data_preprocessor.cc
@@ -60,7 +60,8 @@ absl::StatusOr<ProcessedData> EventDataPreprocessor::Process(
   ProcessedData processed_data;
   ASSIGN_OR_RETURN(
       processed_data.encrypted_event_data,
-      aes_hkdf_.Encrypt(event_data, SecretDataFromStringView(identifier),
+      aes_hkdf_.Encrypt(event_data,
+                        SecretDataFromStringView(encrypted_identifier),
                         hkdf_pepper_));
 
   processed_data.encrypted_identifier =

--- a/src/test/cc/wfa/panelmatch/protocol/crypto/event_data_preprocessor_test.cc
+++ b/src/test/cc/wfa/panelmatch/protocol/crypto/event_data_preprocessor_test.cc
@@ -140,7 +140,9 @@ TEST(EventDataPreprocessorTest, Success) {
   //                 + length added by FakeCipher       [41]
   EXPECT_EQ(processed.encrypted_identifier, 78);
   EXPECT_EQ(processed.encrypted_event_data,
-            "AesEncrypt(input='some-event', key='HKDF(ikm='some-identifier', "
+            "AesEncrypt(input='some-event', "
+            "key='HKDF(ikm='DeterministicCommutativeCipher::Encrypt(some-"
+            "identifier)', "
             "length=64, salt='hkdf-pepper')')");
 }
 


### PR DESCRIPTION
The bug is that the raw identifier is used to form the AES key used to encrypt each event. The correct value to use to form the AES key is the encrypted (but not hashed) identifier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/236)
<!-- Reviewable:end -->
