### PR TITLE
Add status reporter

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/common/ExchangeContext.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/common/ExchangeContext.kt
@@ -21,6 +21,7 @@ import org.wfanet.panelmatch.common.ExchangeDateKey
 
 /** Contextual information about an ExchangeStepAttempt. */
 data class ExchangeContext(
+  val jobId: String,
   val attemptKey: ExchangeStepAttemptKey,
   val date: LocalDate,
   val workflow: ExchangeWorkflow,

--- a/src/main/kotlin/org/wfanet/panelmatch/client/deploy/example/filesystem/FilesystemExampleDaemonMain.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/deploy/example/filesystem/FilesystemExampleDaemonMain.kt
@@ -15,10 +15,15 @@
 package org.wfanet.panelmatch.client.deploy.example.filesystem
 
 import java.io.File
+import java.time.Duration
+import java.util.UUID
 import org.wfanet.measurement.common.commandLineMain
+import org.wfanet.measurement.common.throttler.MinimumIntervalThrottler
+import org.wfanet.measurement.common.throttler.Throttler
 import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.measurement.storage.filesystem.FileSystemStorageClient
 import org.wfanet.panelmatch.client.deploy.example.ExampleDaemon
+import org.wfanet.panelmatch.client.launcher.ExchangeStepReporterToStorage
 import org.wfanet.panelmatch.common.certificates.CertificateAuthority
 import picocli.CommandLine.Option
 
@@ -37,6 +42,14 @@ private class FileSystemExampleDaemon : ExampleDaemon() {
 
   override val certificateAuthority: CertificateAuthority
     get() = TODO("Not yet implemented")
+
+  override val generateJobId = { UUID.randomUUID().toString() }
+
+  private val pollingInterval: Duration = Duration.ofMillis(5 * 60 * 1000)
+  private val statusThrottler: Throttler = MinimumIntervalThrottler(clock, pollingInterval)
+  private val reporterStorageClient = FileSystemStorageClient(privateStorageRoot)
+  override val exchangeStepReporter =
+    ExchangeStepReporterToStorage(apiClient, reporterStorageClient, statusThrottler)
 }
 
 /** Example implementation of a daemon for executing Exchange Workflows. */

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ApiClient.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ApiClient.kt
@@ -17,13 +17,10 @@ package org.wfanet.panelmatch.client.launcher
 import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttempt
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
+import org.wfanet.panelmatch.protocol.ClaimedExchangeStep
 
 /** Abstracts interactions with the centralized Panel Match APIs. */
 interface ApiClient {
-  data class ClaimedExchangeStep(
-    val exchangeStep: ExchangeStep,
-    val exchangeStepAttempt: ExchangeStepAttemptKey
-  )
 
   /**
    * Attempts to fetch an [ExchangeStep] to work on.
@@ -35,8 +32,8 @@ interface ApiClient {
   /** Attaches debug log entries to an [ExchangeStepAttempt]. */
   suspend fun appendLogEntry(key: ExchangeStepAttemptKey, messages: Iterable<String>)
 
-  /** Marks an ExchangeStepAttempt as complete (successfully or otherwise). */
-  suspend fun finishExchangeStepAttempt(
+  /** Reports ExchangeStepAttempt as complete (successfully or otherwise). */
+  suspend fun reportStepAttempt(
     key: ExchangeStepAttemptKey,
     finalState: ExchangeStepAttempt.State,
     logEntryMessages: Iterable<String> = emptyList()

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
@@ -27,7 +27,13 @@ class CoroutineLauncher(
   private val scope: CoroutineScope = CoroutineScope(Dispatchers.Default),
   private val stepExecutor: ExchangeStepExecutor
 ) : JobLauncher {
-  override suspend fun execute(step: ValidatedExchangeStep, attemptKey: ExchangeStepAttemptKey) {
-    scope.launch(CoroutineName(attemptKey.toName())) { stepExecutor.execute(step, attemptKey) }
+  override suspend fun execute(
+    jobId: String,
+    step: ValidatedExchangeStep,
+    attemptKey: ExchangeStepAttemptKey
+  ) {
+    scope.launch(CoroutineName(attemptKey.toName())) {
+      stepExecutor.execute(jobId, step, attemptKey)
+    }
   }
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepExecutor.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepExecutor.kt
@@ -21,5 +21,9 @@ import org.wfanet.panelmatch.client.launcher.ExchangeStepValidator.ValidatedExch
 /** Executes [ExchangeWorkflow.Step]s. */
 interface ExchangeStepExecutor {
   /** Executes [step]. */
-  suspend fun execute(validatedStep: ValidatedExchangeStep, attemptKey: ExchangeStepAttemptKey)
+  suspend fun execute(
+    jobId: String,
+    validatedStep: ValidatedExchangeStep,
+    attemptKey: ExchangeStepAttemptKey
+  )
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepReporter.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepReporter.kt
@@ -14,22 +14,26 @@
 
 package org.wfanet.panelmatch.client.launcher
 
-import org.wfanet.measurement.api.v2alpha.ExchangeStep
+import org.wfanet.measurement.api.v2alpha.ExchangeStepAttempt
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
-import org.wfanet.panelmatch.client.launcher.ExchangeStepValidator.ValidatedExchangeStep
+import org.wfanet.panelmatch.protocol.ClaimedExchangeStep
 
-/** Executes an [ExchangeStep]. This may be locally or remotely. */
-interface JobLauncher {
-  /**
-   * Initiates work on [step].
-   *
-   * This may return before the work is complete.
-   *
-   * This could run [step] in-process or enqueue/start work remotely, e.g. via an RPC call.
-   */
-  suspend fun execute(
+interface ExchangeStepReporter {
+
+  suspend fun getAndStoreClaimStatus(
     jobId: String,
-    step: ValidatedExchangeStep,
-    attemptKey: ExchangeStepAttemptKey
+  ): ClaimedExchangeStep?
+
+  suspend fun getClaimStatus(
+    jobId: String,
+  ): ClaimedExchangeStep
+
+  suspend fun storeExecutionStatus(
+    jobId: String,
+    key: ExchangeStepAttemptKey,
+    state: ExchangeStepAttempt.State,
+    logEntryMessages: Iterable<String> = emptyList()
   )
+
+  suspend fun reportExecutionStatus(jobId: String)
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepReporterToStorage.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepReporterToStorage.kt
@@ -1,0 +1,88 @@
+// Copyright 2021 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.launcher
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.wfanet.measurement.api.v2alpha.ExchangeStepAttempt
+import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
+import org.wfanet.measurement.common.throttler.Throttler
+import org.wfanet.measurement.storage.StorageClient
+import org.wfanet.panelmatch.common.storage.createOrReplaceBlob
+import org.wfanet.panelmatch.common.storage.toByteString
+import org.wfanet.panelmatch.protocol.ClaimedExchangeStep
+import org.wfanet.panelmatch.protocol.ExchangeStepStatus
+import org.wfanet.panelmatch.protocol.exchangeStepStatus
+
+class ExchangeStepReporterToStorage(
+  private val apiClient: ApiClient,
+  private val storageClient: StorageClient,
+  private val statusThrottler: Throttler
+) : ExchangeStepReporter {
+
+  override suspend fun getAndStoreClaimStatus(
+    jobId: String,
+  ): ClaimedExchangeStep? {
+    val claimedStep = apiClient.claimExchangeStep() ?: return null
+    storageClient.createOrReplaceBlob(jobId, claimedStep.toByteString())
+    return claimedStep
+  }
+
+  override suspend fun getClaimStatus(
+    jobId: String,
+  ): ClaimedExchangeStep {
+    print("GET C STATUS!!!\n\n")
+    return ClaimedExchangeStep.parseFrom(storageClient.getBlob(jobId)!!.toByteString())
+  }
+
+  override suspend fun storeExecutionStatus(
+    jobId: String,
+    key: ExchangeStepAttemptKey,
+    state: ExchangeStepAttempt.State,
+    logEntryMessages: Iterable<String>
+  ) {
+    val attemptStatus = exchangeStepStatus {
+      this.key = key.toName()
+      this.state = state
+      logs += logEntryMessages
+    }
+    storageClient.createOrReplaceBlob(jobId, attemptStatus.toByteString())
+  }
+
+  override suspend fun reportExecutionStatus(jobId: String) {
+    CoroutineScope(Dispatchers.Default).launch {
+      var executionStatus: ExchangeStepStatus? = null
+      while (executionStatus == null) {
+        if (statusThrottler.onReady { getExecutionStatus(jobId) != null }) {
+          executionStatus = getExecutionStatus(jobId)!!
+        }
+      }
+      apiClient.reportStepAttempt(
+        ExchangeStepAttemptKey.fromName(executionStatus.key)!!,
+        executionStatus.state,
+        executionStatus.logsList
+      )
+    }
+  }
+
+  private suspend fun getExecutionStatus(jobId: String): ExchangeStepStatus? {
+    return try {
+      ExchangeStepStatus.parseFrom(storageClient.getBlob(jobId)!!.toByteString())
+    } catch (_: Exception) {
+      null
+    }
+  }
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/GrpcApiClient.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/GrpcApiClient.kt
@@ -29,7 +29,8 @@ import org.wfanet.measurement.api.v2alpha.finishExchangeStepAttemptRequest
 import org.wfanet.measurement.common.grpc.grpcRequireNotNull
 import org.wfanet.measurement.common.toProtoTime
 import org.wfanet.panelmatch.client.common.Identity
-import org.wfanet.panelmatch.client.launcher.ApiClient.ClaimedExchangeStep
+import org.wfanet.panelmatch.protocol.ClaimedExchangeStep
+import org.wfanet.panelmatch.protocol.claimedExchangeStep
 
 class GrpcApiClient(
   private val identity: Identity,
@@ -50,7 +51,10 @@ class GrpcApiClient(
     if (response.hasExchangeStep()) {
       val exchangeStepAttemptKey =
         grpcRequireNotNull(ExchangeStepAttemptKey.fromName(response.exchangeStepAttempt))
-      return ClaimedExchangeStep(response.exchangeStep, exchangeStepAttemptKey)
+      return claimedExchangeStep {
+        step = response.exchangeStep
+        stepAttemptKey = exchangeStepAttemptKey.toName()
+      }
     }
     return null
   }
@@ -65,7 +69,7 @@ class GrpcApiClient(
     exchangeStepAttemptsClient.appendLogEntry(request)
   }
 
-  override suspend fun finishExchangeStepAttempt(
+  override suspend fun reportStepAttempt(
     key: ExchangeStepAttemptKey,
     finalState: ExchangeStepAttempt.State,
     logEntryMessages: Iterable<String>

--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/testing/TestStorageClients.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/testing/TestStorageClients.kt
@@ -77,6 +77,7 @@ private val WORKFLOW = exchangeWorkflow {
 
 private val TEST_CONTEXT =
   ExchangeContext(
+    "some-job-id",
     ExchangeStepAttemptKey(
       "some-recurring-exchange-id",
       "some-exchange-id",

--- a/src/main/proto/wfa/panelmatch/client/exchangetasks/BUILD.bazel
+++ b/src/main/proto/wfa/panelmatch/client/exchangetasks/BUILD.bazel
@@ -31,6 +31,11 @@ proto_library(
     name = "exchangesteps_proto",
     srcs = ["exchangesteps.proto"],
     strip_import_prefix = "/src/main/proto",
+    deps = [
+        "@com_google_googleapis//google/type:date_proto",
+        "@wfa_measurement_proto//src/main/proto/wfa/measurement/api/v2alpha:exchange_step_attempt_proto",
+        "@wfa_measurement_proto//src/main/proto/wfa/measurement/api/v2alpha:exchange_step_proto",
+    ],
 )
 
 java_proto_library(

--- a/src/main/proto/wfa/panelmatch/client/exchangetasks/exchangesteps.proto
+++ b/src/main/proto/wfa/panelmatch/client/exchangetasks/exchangesteps.proto
@@ -16,6 +16,10 @@ syntax = "proto3";
 
 package wfa.panelmatch.protocol;
 
+import "google/type/date.proto";
+import "wfa/measurement/api/v2alpha/exchange_step.proto";
+import "wfa/measurement/api/v2alpha/exchange_step_attempt.proto";
+
 option java_package = "org.wfanet.panelmatch.protocol";
 option java_multiple_files = true;
 
@@ -23,4 +27,22 @@ message NamedSignature {
   bytes signature = 1;
   // The API resource name of the certificate that provided this signature
   string certificate_name = 2;
+}
+
+message ExchangeStepKey {
+  wfa.measurement.api.v2alpha.ExchangeStep exchange_step = 1;
+}
+
+message ClaimedExchangeStep {
+  string recurring_exchange_id = 1;
+  google.type.Date date = 2;
+  wfa.measurement.api.v2alpha.ExchangeStep step = 3;
+  string step_attempt_key = 4;
+}
+
+// The state of an exchange step
+message ExchangeStepStatus {
+  string key = 1;
+  wfa.measurement.api.v2alpha.ExchangeStepAttempt.State state = 2;
+  repeated string logs = 3;
 }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskMapperTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskMapperTest.kt
@@ -41,7 +41,7 @@ private val WORKFLOW = exchangeWorkflow {
 }
 
 private val DATE: LocalDate = LocalDate.of(2021, 11, 1)
-
+private const val JOB_ID = "some-job-id"
 private const val RECURRING_EXCHANGE_ID = "some-recurring-exchange-id"
 private val ATTEMPT_KEY =
   ExchangeStepAttemptKey(RECURRING_EXCHANGE_ID, "some-exchange", "some-step", "some-attempt")
@@ -64,7 +64,7 @@ class ExchangeTaskMapperTest {
 
   @Test
   fun `map input task`() = runBlockingTest {
-    val context = ExchangeContext(ATTEMPT_KEY, DATE, WORKFLOW, WORKFLOW.getSteps(0))
+    val context = ExchangeContext(JOB_ID, ATTEMPT_KEY, DATE, WORKFLOW, WORKFLOW.getSteps(0))
     val exchangeTask = exchangeTaskMapper.getExchangeTaskForStep(context)
     assertThat(exchangeTask).isInstanceOf(FakeExchangeTask::class.java)
     assertThat((exchangeTask as FakeExchangeTask).taskName).isEqualTo("input")
@@ -72,7 +72,7 @@ class ExchangeTaskMapperTest {
 
   @Test
   fun `map crypto task`() = runBlockingTest {
-    val context = ExchangeContext(ATTEMPT_KEY, DATE, WORKFLOW, WORKFLOW.getSteps(1))
+    val context = ExchangeContext(JOB_ID, ATTEMPT_KEY, DATE, WORKFLOW, WORKFLOW.getSteps(1))
     val exchangeTask = exchangeTaskMapper.getExchangeTaskForStep(context)
     assertThat(exchangeTask).isInstanceOf(FakeExchangeTask::class.java)
     assertThat((exchangeTask as FakeExchangeTask).taskName)

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/BUILD.bazel
@@ -1,10 +1,10 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 kt_jvm_test(
-    name = "ExchangeStepLauncherTest",
+    name = "ExchangeStepManagerTest",
     timeout = "short",
-    srcs = ["ExchangeStepLauncherTest.kt"],
-    test_class = "org.wfanet.panelmatch.client.launcher.ExchangeStepLauncherTest",
+    srcs = ["ExchangeStepManagerTest.kt"],
+    test_class = "org.wfanet.panelmatch.client.launcher.ExchangeStepManagerTest",
     deps = [
         "//src/main/kotlin/org/wfanet/panelmatch/client/launcher",
         "//src/main/kotlin/org/wfanet/panelmatch/common/testing",


### PR DESCRIPTION
Currently, the stepExecutor takes in an ApiClient to its constructor. This doesn't work for execution environments that do not have network access. Instead, we propose a statusReporter that writes out storage. One example has been written that uses a storage client but others could be written that use a sql database for example. 

I've also added a new parameter, jobId, that keeps track of the job across the stages. Its currently a UUID in the example daemon but could be passed in as a parameter if the daemon is used as a one-time worker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/265)
<!-- Reviewable:end -->
