### PR TITLE
fix bug where hash code can be negative

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/PreprocessEvents.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/PreprocessEvents.kt
@@ -75,7 +75,7 @@ class PreprocessEventsTransform(
   override fun expand(events: PCollection<UnprocessedEvent>): PCollection<DatabaseEntry> {
     return events
       .map<UnprocessedEvent, KV<ByteString, ByteString>>("Map to KV") { kvOf(it.id, it.data) }
-      .groupByKey()
+      .groupByKey("Group Events")
       .mapValues("Make CombinedEvents") { combinedEvents { serializedEvents += it }.toByteString() }
       .parDo(BatchingDoFn(maxByteSize, EventSize), name = "Batch by $maxByteSize bytes")
       .apply(

--- a/src/main/kotlin/org/wfanet/panelmatch/common/ShardedFileName.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/ShardedFileName.kt
@@ -49,7 +49,7 @@ data class ShardedFileName(val spec: String) : Serializable {
   }
 
   fun fileNameForShard(i: Int): String {
-    require(i in 0 until shardCount)
+    require(i in 0 until shardCount) { "Shard $i must be in 0..$shardCount" }
     val digits = shardCount.toString().length
     return "$baseName-%0${digits}d-of-$shardCount".format(i)
   }

--- a/src/main/kotlin/org/wfanet/panelmatch/common/beam/WriteShardedData.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/beam/WriteShardedData.kt
@@ -15,6 +15,7 @@
 package org.wfanet.panelmatch.common.beam
 
 import com.google.protobuf.Message
+import kotlin.math.abs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.map
@@ -65,7 +66,7 @@ class WriteShardedData<T : Message>(
     val shardCount = shardedFileName.shardCount
     val filesWritten =
       input
-        .keyBy("Key by Blob") { it.hashCode() % shardCount }
+        .keyBy("Key by Blob") { abs(it.hashCode()) % shardCount }
         .apply("Group by Blob", GroupByKey.create())
         .apply("Write $fileSpec", ParDo.of(WriteFilesFn(fileSpec, storageFactory)))
 

--- a/src/test/kotlin/org/wfanet/panelmatch/integration/config/full_with_preprocessing.textproto
+++ b/src/test/kotlin/org/wfanet/panelmatch/integration/config/full_with_preprocessing.textproto
@@ -467,7 +467,7 @@ steps {
 
   execute_private_membership_queries_step {
     serialized_parameters: "\n\b\b\001\020\v\030\001(\001\022#\n\020\201\300\270\377\377\377\377\377\377\001\377\377\377\377\377\003\022\003\201\300}\030\f \001(\b0\0028\004@\n"
-    encrypted_query_result_file_count: 1
+    encrypted_query_result_file_count: 2
     num_shards: 1
     num_buckets_per_shard: 10
     max_queries_per_shard: 10


### PR DESCRIPTION
Fixes
* The current impl breaks with more than one sharded file. This fixes that issue.
* The preprocess groupbyKey step was unnamed which can be a fatal error in some deployments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/269)
<!-- Reviewable:end -->
