### PR TITLE
Wrap GcsStorageClient with a prefixed factory

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/storage/gcloud/gcs/GcsStorageFactory.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/storage/gcloud/gcs/GcsStorageFactory.kt
@@ -24,6 +24,7 @@ import org.wfanet.panelmatch.client.storage.StorageDetails
 import org.wfanet.panelmatch.client.storage.StorageDetails.BucketType
 import org.wfanet.panelmatch.common.ExchangeDateKey
 import org.wfanet.panelmatch.common.storage.StorageFactory
+import org.wfanet.panelmatch.common.storage.withPrefix
 
 class GcsStorageFactory(
   private val storageDetails: StorageDetails,
@@ -45,9 +46,10 @@ class GcsStorageFactory(
           error("Invalid bucket_type: $bucketType")
       }
     return GcsStorageClient(
-      StorageOptions.newBuilder().setProjectId(gcs.projectName).build().service,
-      bucketId
-    )
+        StorageOptions.newBuilder().setProjectId(gcs.projectName).build().service,
+        bucketId
+      )
+      .withPrefix(exchangeDateKey.path)
   }
 }
 


### PR DESCRIPTION
- This is to prevent collisions when using a static bucket
- We use it for both rotating buckets and static buckets so there isn't
  a hidden difference in behaviour that might be harder to debug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/287)
<!-- Reviewable:end -->
