### PR TITLE
Use a SupervisorJob within CoroutineLauncher.

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/CoroutineLauncher.kt
@@ -17,7 +17,9 @@ package org.wfanet.panelmatch.client.launcher
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
 import org.wfanet.measurement.api.v2alpha.ExchangeStep
 import org.wfanet.measurement.api.v2alpha.ExchangeStepAttemptKey
 import org.wfanet.panelmatch.client.launcher.ExchangeStepValidator.ValidatedExchangeStep
@@ -28,6 +30,8 @@ class CoroutineLauncher(
   private val stepExecutor: ExchangeStepExecutor
 ) : JobLauncher {
   override suspend fun execute(step: ValidatedExchangeStep, attemptKey: ExchangeStepAttemptKey) {
-    scope.launch(CoroutineName(attemptKey.toName())) { stepExecutor.execute(step, attemptKey) }
+    (scope + SupervisorJob()).launch(CoroutineName(attemptKey.toName())) {
+      stepExecutor.execute(step, attemptKey)
+    }
   }
 }


### PR DESCRIPTION
This prevents cancellations within the ExchangeStepExecutor from cancelling the CoroutineLauncher's scope. If this scope becomes cancelled then ExchangeStepLauncher.findAndRunExchangeStep will continue
to claim new work but immediately mark it as failed, as it tries to execute a coroutine in a cancelled scope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/291)
<!-- Reviewable:end -->
