### PR TITLE
Throw transient instead of permanent error for missing ExchangeWorkflow

### DIFF
--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepValidatorImplTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeStepValidatorImplTest.kt
@@ -47,6 +47,7 @@ private const val EXCHANGE_ID = "some-exchange-id"
 private const val EXCHANGE_STEP_ID = "some-exchange-step-id"
 
 private const val OTHER_RECURRING_EXCHANGE_ID = "some-other-recurring-exchange-id"
+private const val MISSING_RECURRING_EXCHANGE_ID = "some-missing-recurring-exchange-id"
 
 private val EXCHANGE_WORKFLOW = exchangeWorkflow {
   firstExchangeDate = FIRST_EXCHANGE_DATE.toProtoDate()
@@ -112,6 +113,16 @@ class ExchangeStepValidatorImplTest {
     val wrongExchangeStep =
       EXCHANGE_STEP.copy { serializedExchangeWorkflow = wrongExchangeWorkflow.toByteString() }
     assertValidationFailsPermanently(wrongExchangeStep)
+  }
+
+  @Test
+  fun missingRecurringExchange() {
+    val wrongExchangeStep =
+      EXCHANGE_STEP.copy {
+        name =
+          ExchangeStepKey(MISSING_RECURRING_EXCHANGE_ID, EXCHANGE_ID, EXCHANGE_STEP_ID).toName()
+      }
+    assertValidationFailsTransiently(wrongExchangeStep)
   }
 
   @Test


### PR DESCRIPTION
This fixes a pain point: when adding a new RecurringExchange that starts in the past, there's a circular dependency. In order to set up some required inputs, like the private list of valid ExchangeWorkflows, the RecurringExchange id is needed. But as soon as the RecurringExchange is created, any running client will start picking up tasks for it and permanently failing them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/298)
<!-- Reviewable:end -->
