### PR TITLE
add health grpc

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/testing/BUILD.bazel
@@ -37,6 +37,7 @@ java_library(
         "//src/main/kotlin/org/wfanet/panelmatch/common/testing",
         "//src/main/kotlin/org/wfanet/panelmatch/integration",
         "//src/main/kotlin/org/wfanet/panelmatch/integration/testing",
+        "@wfa_common_jvm//imports/kotlin/io/grpc/health/v1:health_kt_jvm_grpc",
     ],
 )
 

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutorTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutorTest.kt
@@ -45,12 +45,11 @@ private val ATTEMPT_KEY = ExchangeStepAttemptKey(RECURRING_EXCHANGE_ID, "x", "y"
 private val DATE = LocalDate.of(2021, 11, 3)
 
 private val WORKFLOW = exchangeWorkflow {
-  steps +=
-    step {
-      this.commutativeDeterministicEncryptStep = commutativeDeterministicEncryptStep {}
-      inputLabels["a"] = "b"
-      outputLabels["Out:a"] = "c"
-    }
+  steps += step {
+    this.commutativeDeterministicEncryptStep = commutativeDeterministicEncryptStep {}
+    inputLabels["a"] = "b"
+    outputLabels["Out:a"] = "c"
+  }
 }
 
 private val VALIDATED_EXCHANGE_STEP = ValidatedExchangeStep(WORKFLOW, WORKFLOW.getSteps(0), DATE)

--- a/src/test/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutorTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutorTest.kt
@@ -45,11 +45,12 @@ private val ATTEMPT_KEY = ExchangeStepAttemptKey(RECURRING_EXCHANGE_ID, "x", "y"
 private val DATE = LocalDate.of(2021, 11, 3)
 
 private val WORKFLOW = exchangeWorkflow {
-  steps += step {
-    this.commutativeDeterministicEncryptStep = commutativeDeterministicEncryptStep {}
-    inputLabels["a"] = "b"
-    outputLabels["Out:a"] = "c"
-  }
+  steps +=
+    step {
+      this.commutativeDeterministicEncryptStep = commutativeDeterministicEncryptStep {}
+      inputLabels["a"] = "b"
+      outputLabels["Out:a"] = "c"
+    }
 }
 
 private val VALIDATED_EXCHANGE_STEP = ValidatedExchangeStep(WORKFLOW, WORKFLOW.getSteps(0), DATE)


### PR DESCRIPTION
For debugging purposes, it is helpful for the client to have the grpc health check resource. Future tests to this repo could include example tests showing how to utilize the grpc health check resource for a basic mtls test to make sure the client is correctly configured.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/304)
<!-- Reviewable:end -->
