### PR TITLE
Reduce parallelism of copy to/from shared storage steps.

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/CopyFromSharedStorageTask.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/CopyFromSharedStorageTask.kt
@@ -34,7 +34,7 @@ class CopyFromSharedStorageTask(
   private val copyOptions: CopyOptions,
   private val sourceBlobKey: String,
   private val destinationBlobKey: String,
-  private val maxParallelTransfers: Int = 32,
+  private val maxParallelTransfers: Int = 16,
 ) : CustomIOExchangeTask() {
   override suspend fun execute() {
     val blob = source.getBlob(sourceBlobKey)

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/CopyToSharedStorageTask.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/CopyToSharedStorageTask.kt
@@ -34,7 +34,7 @@ class CopyToSharedStorageTask(
   private val copyOptions: CopyOptions,
   private val sourceBlobKey: String,
   private val destinationBlobKey: String,
-  private val maxParallelTransfers: Int = 32,
+  private val maxParallelTransfers: Int = 16,
 ) : CustomIOExchangeTask() {
   override suspend fun execute() {
     val blob = readBlob(sourceBlobKey)


### PR DESCRIPTION
In internal testing, setting the parallelism too high led to out-of-memory errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/306)
<!-- Reviewable:end -->
