### PR TITLE
Initial full support of padding queries in DecryptQueryResults

### DIFF
--- a/src/main/cc/wfa/panelmatch/client/privatemembership/decrypt_query_results.cc
+++ b/src/main/cc/wfa/panelmatch/client/privatemembership/decrypt_query_results.cc
@@ -101,8 +101,11 @@ absl::Status Decompress(const CompressionParameters& compression_parameters,
                    MakeCompressor(compression_parameters));
   for (auto& data_set : *response.mutable_event_data_sets()) {
     for (Plaintext& plaintext : *data_set.mutable_decrypted_event_data()) {
-      ASSIGN_OR_RETURN(*plaintext.mutable_payload(),
-                       compressor->Decompress(plaintext.payload()));
+      absl::StatusOr<std::string> decompressed_payload =
+          compressor->Decompress(plaintext.payload());
+      if (decompressed_payload.ok()) {
+        *plaintext.mutable_payload() = *std::move(decompressed_payload);
+      }
     }
   }
   return absl::OkStatus();

--- a/src/main/kotlin/org/wfanet/panelmatch/common/beam/Beam.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/beam/Beam.kt
@@ -161,8 +161,8 @@ inline fun <reified KeyT, reified LeftT, reified RightT> PCollection<
 ): PCollection<KV<LeftT, RightT>> {
   return oneToOneJoin(right, name = "$name/Join").map("$name/RequireNotNull") {
     kvOf(
-      requireNotNull(it.key) { "Key is missing" },
-      requireNotNull(it.value) { "Value is missing" }
+      requireNotNull(it.key) { "Key is missing in strictOneToOneJoin '$name'" },
+      requireNotNull(it.value) { "Value is missing in strictOneToOneJoin '$name'" }
     )
   }
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/integration/testing/BUILD.bazel
+++ b/src/main/kotlin/org/wfanet/panelmatch/integration/testing/BUILD.bazel
@@ -12,6 +12,7 @@ kt_jvm_library(
     name = "testing",
     srcs = glob(["*.kt"]),
     deps = [
+        "//src/main/kotlin/org/wfanet/panelmatch/client/privatemembership",
         "//src/main/proto/wfa/panelmatch/client/eventpreprocessing:combined_events_kt_jvm_proto",
         "//src/main/proto/wfa/panelmatch/client/privatemembership:decrypt_event_data_kt_jvm_proto",
     ],

--- a/src/test/kotlin/org/wfanet/panelmatch/integration/FullWorkflowTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/integration/FullWorkflowTest.kt
@@ -60,13 +60,12 @@ private fun makeDatabaseEntry(index: Int): DatabaseEntry {
     hkdfPepper = EDP_HKDF_PEPPER
     identifierHashPepper = EDP_IDENTIFIER_HASH_PEPPER
     compressionParameters = EDP_COMPRESSION_PARAMETERS
-    unprocessedEvents +=
-      unprocessedEvent {
-        id = "join-key-$index".toByteStringUtf8()
-        data =
-          combinedEvents { serializedEvents += "payload-for-join-key-$index".toByteStringUtf8() }
-            .toByteString()
-      }
+    unprocessedEvents += unprocessedEvent {
+      id = "join-key-$index".toByteStringUtf8()
+      data =
+        combinedEvents { serializedEvents += "payload-for-join-key-$index".toByteStringUtf8() }
+          .toByteString()
+    }
   }
   val response = JniEventPreprocessor().preprocess(request)
   val processedEvent = response.processedEventsList.single()
@@ -76,7 +75,7 @@ private fun makeDatabaseEntry(index: Int): DatabaseEntry {
   )
 }
 
-private val EDP_DATABASE_ENTRIES = (0 until 100).map { makeDatabaseEntry(it) }
+private val EDP_DATABASE_ENTRIES = (0 until 10).map { makeDatabaseEntry(it) }
 
 private val EDP_ENCRYPTED_EVENT_DATA_BLOB =
   EDP_DATABASE_ENTRIES.map { it.toDelimitedByteString() }.flatten()
@@ -117,9 +116,11 @@ class FullWorkflowTest : AbstractInProcessPanelMatchIntegrationTest() {
         it.joinKey to it.plaintexts
       }
     assertThat(decryptedEvents)
-      .containsExactly(
+      .containsAtLeast(
         "join-key-1" to listOf("payload-for-join-key-1"),
         "join-key-2" to listOf("payload-for-join-key-2"),
       )
+
+    assertThat(decryptedEvents).hasSize(3) // 1 padding nonce expected
   }
 }

--- a/src/test/kotlin/org/wfanet/panelmatch/integration/config/full_exchange_workflow.textproto
+++ b/src/test/kotlin/org/wfanet/panelmatch/integration/config/full_exchange_workflow.textproto
@@ -311,26 +311,25 @@ steps {
 
   generate_serialized_rlwe_key_pair_step {
     parameters: {
-        [type.googleapis.com/private_membership.batch.Parameters]
-        {
-            shard_parameters: {
-                number_of_shards: 1
-                number_of_buckets_per_shard: 11
-                required_queries_per_shard: 1
-                enable_padding_nonces: 1
-            }
-            crypto_parameters: {
-                request_modulus: 18446744073708380161
-                request_modulus: 137438953471
-                response_modulus: 2056193
-                log_degree: 12
-                log_t: 1
-                variance: 8
-                levels_of_recursion: 2
-                log_compression_factor: 4
-                log_decomposition_modulus: 10
-            }
+      [type.googleapis.com/private_membership.batch.Parameters] {
+        shard_parameters: {
+          number_of_shards: 1
+          number_of_buckets_per_shard: 11
+          required_queries_per_shard: 3
+          enable_padding_nonces: 1
         }
+        crypto_parameters: {
+          request_modulus: 18446744073708380161
+          request_modulus: 137438953471
+          response_modulus: 2056193
+          log_degree: 12
+          log_t: 1
+          variance: 8
+          levels_of_recursion: 2
+          log_compression_factor: 4
+          log_decomposition_modulus: 10
+        }
+      }
     }
   }
 
@@ -345,33 +344,32 @@ steps {
 
   build_private_membership_queries_step {
     parameters: {
-        [type.googleapis.com/private_membership.batch.Parameters]
-        {
-            shard_parameters: {
-                number_of_shards: 1
-                number_of_buckets_per_shard: 11
-                required_queries_per_shard: 1
-                enable_padding_nonces: 1
-            }
-            crypto_parameters: {
-                request_modulus: 18446744073708380161
-                request_modulus: 137438953471
-                response_modulus: 2056193
-                log_degree: 12
-                log_t: 1
-                variance: 8
-                levels_of_recursion: 2
-                log_compression_factor: 4
-                log_decomposition_modulus: 10
-            }
+      [type.googleapis.com/private_membership.batch.Parameters] {
+        shard_parameters: {
+          number_of_shards: 1
+          number_of_buckets_per_shard: 11
+          required_queries_per_shard: 3
+          enable_padding_nonces: 1
         }
+        crypto_parameters: {
+          request_modulus: 18446744073708380161
+          request_modulus: 137438953471
+          response_modulus: 2056193
+          log_degree: 12
+          log_t: 1
+          variance: 8
+          levels_of_recursion: 2
+          log_compression_factor: 4
+          log_decomposition_modulus: 10
+        }
+      }
     }
     encrypted_query_bundle_file_count: 1
     query_id_to_ids_file_count: 1
     num_shards: 1
     num_buckets_per_shard: 10
-    num_queries_per_shard: 10
-    add_padding_queries: false
+    num_queries_per_shard: 3
+    add_padding_queries: true
   }
 
   input_labels { key: "lookup-keys" value: "mp-lookup-keys" }
@@ -475,26 +473,25 @@ steps {
 
   execute_private_membership_queries_step {
     parameters: {
-        [type.googleapis.com/private_membership.batch.Parameters]
-        {
-            shard_parameters: {
-                number_of_shards: 1
-                number_of_buckets_per_shard: 11
-                required_queries_per_shard: 1
-                enable_padding_nonces: 1
-            }
-            crypto_parameters: {
-                request_modulus: 18446744073708380161
-                request_modulus: 137438953471
-                response_modulus: 2056193
-                log_degree: 12
-                log_t: 1
-                variance: 8
-                levels_of_recursion: 2
-                log_compression_factor: 4
-                log_decomposition_modulus: 10
-            }
+      [type.googleapis.com/private_membership.batch.Parameters] {
+        shard_parameters: {
+          number_of_shards: 1
+          number_of_buckets_per_shard: 11
+          required_queries_per_shard: 3
+          enable_padding_nonces: 1
         }
+        crypto_parameters: {
+          request_modulus: 18446744073708380161
+          request_modulus: 137438953471
+          response_modulus: 2056193
+          log_degree: 12
+          log_t: 1
+          variance: 8
+          levels_of_recursion: 2
+          log_compression_factor: 4
+          log_decomposition_modulus: 10
+        }
+      }
     }
     encrypted_query_result_file_count: 1
     num_shards: 1
@@ -539,26 +536,25 @@ steps {
 
   decrypt_private_membership_query_results_step {
     parameters: {
-        [type.googleapis.com/private_membership.batch.Parameters]
-        {
-            shard_parameters: {
-                number_of_shards: 1
-                number_of_buckets_per_shard: 11
-                required_queries_per_shard: 1
-                enable_padding_nonces: 1
-            }
-            crypto_parameters: {
-                request_modulus: 18446744073708380161
-                request_modulus: 137438953471
-                response_modulus: 2056193
-                log_degree: 12
-                log_t: 1
-                variance: 8
-                levels_of_recursion: 2
-                log_compression_factor: 4
-                log_decomposition_modulus: 10
-            }
+      [type.googleapis.com/private_membership.batch.Parameters] {
+        shard_parameters: {
+          number_of_shards: 1
+          number_of_buckets_per_shard: 11
+          required_queries_per_shard: 3
+          enable_padding_nonces: 1
         }
+        crypto_parameters: {
+          request_modulus: 18446744073708380161
+          request_modulus: 137438953471
+          response_modulus: 2056193
+          log_degree: 12
+          log_t: 1
+          variance: 8
+          levels_of_recursion: 2
+          log_compression_factor: 4
+          log_decomposition_modulus: 10
+        }
+      }
     }
     decrypt_event_data_set_file_count: 1
   }


### PR DESCRIPTION
This is a bit of a short-term hack. Right now, we use the JoinKeyIdentifier to determine if the payload should be parsed as a query result or as a padding nonce. Ideally, there would just be a one-of in a proto somewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/314)
<!-- Reviewable:end -->
