### PR TITLE
Clean up padding nonce handling in DecryptQueryResults

### DIFF
--- a/src/main/cc/wfa/panelmatch/client/privatemembership/event_data_decryptor.cc
+++ b/src/main/cc/wfa/panelmatch/client/privatemembership/event_data_decryptor.cc
@@ -49,12 +49,6 @@ absl::StatusOr<DecryptedEventDataSet> DecryptEventData(
   for (const std::string& encrypted_event : request.encrypted_event_data_set()
                                                 .encrypted_event_data()
                                                 .ciphertexts()) {
-    if (key.empty()) {
-      Plaintext* decrypted_event_data = response.add_decrypted_event_data();
-      decrypted_event_data->set_payload(encrypted_event);
-      continue;
-    }
-
     absl::StatusOr<std::string> plaintext = aes_hkdf.Decrypt(
         encrypted_event, key, SecretDataFromStringView(request.hkdf_pepper()));
     if (plaintext.ok()) {

--- a/src/main/kotlin/org/wfanet/panelmatch/client/privatemembership/DecryptQueryResults.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/privatemembership/DecryptQueryResults.kt
@@ -48,12 +48,9 @@ import org.wfanet.panelmatch.common.withTime
 /**
  * Decrypts and decompresses [encryptedQueryResults].
  *
- * There must be a bijection between [QueryId]s in [queryIdAndJoinKeys] and the queries present in
- * [encryptedQueryResults].
- *
  * @param encryptedQueryResults data to be decrypted and decompressed
- * @param plaintextJoinKeyAndId used to tie a decrypted result to its plaintext join key
- * @param decryptedJoinKeyAndId used to remove the final layer of encryption
+ * @param plaintextJoinKeyAndIds used to tie a decrypted result to its plaintext join key
+ * @param decryptedJoinKeyAndIds used to remove the final layer of encryption
  * @param queryIdAndIds a query id tied to its join key identifier
  * @param compressionParameters specifies how to decompress the decrypted event data
  * @param parameters parameters for decryption
@@ -87,7 +84,7 @@ fun decryptQueryResults(
     )
 }
 
-private class DecryptQueryResults(
+class DecryptQueryResults(
   private val parameters: Any,
   private val queryResultsDecryptor: QueryResultsDecryptor,
   private val hkdfPepper: ByteString,
@@ -103,10 +100,10 @@ private class DecryptQueryResults(
         ProtoCoder.of(JoinKeyIdentifier::class.java),
         ListCoder.of(ProtoCoder.of(Plaintext::class.java))
       )
-    val encryptedQueryResults = input[encryptedQueryResultsTag]
-    val queryIdAndIds = input[queryIdAndIdsTag]
-    val decryptedJoinKeyAndIds = input[decryptedJoinKeyAndIdsTag]
-    val plaintextJoinKeyAndIds = input[plaintextJoinKeyAndIdsTag]
+    val encryptedQueryResults: PCollection<EncryptedQueryResult> = input[encryptedQueryResultsTag]
+    val queryIdAndIds: PCollection<QueryIdAndId> = input[queryIdAndIdsTag]
+    val decryptedJoinKeyAndIds: PCollection<JoinKeyAndId> = input[decryptedJoinKeyAndIdsTag]
+    val plaintextJoinKeyAndIds: PCollection<JoinKeyAndId> = input[plaintextJoinKeyAndIdsTag]
 
     val keyedQueryIdAndIds: PCollection<KV<JoinKeyIdentifier, QueryIdAndId>> =
       queryIdAndIds.keyBy("Key QueryIds by Id") { it.joinKeyIdentifier }

--- a/src/main/kotlin/org/wfanet/panelmatch/integration/testing/WorkflowTestHelper.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/integration/testing/WorkflowTestHelper.kt
@@ -18,6 +18,8 @@ import org.wfanet.panelmatch.client.eventpreprocessing.CombinedEvents
 import org.wfanet.panelmatch.client.privatemembership.KeyedDecryptedEventDataSet
 import org.wfanet.panelmatch.client.privatemembership.PADDING_QUERY_JOIN_KEY_IDENTIFIER
 
+const val TEST_PADDING_NONCE_PREFIX: String = "[Padding Nonce]"
+
 data class ParsedPlaintextResults(val joinKey: String, val plaintexts: List<String>)
 
 /**
@@ -33,7 +35,7 @@ fun parsePlaintextResults(
     val payload =
       if (keyAndId.joinKeyIdentifier.id == PADDING_QUERY_JOIN_KEY_IDENTIFIER.id) {
         val element = keyedDecryptedEventDataSet.decryptedEventDataList.single().payload
-        listOf("Padding Nonce: ${element.toStringUtf8()}")
+        listOf("$TEST_PADDING_NONCE_PREFIX ${element.toStringUtf8()}")
       } else {
         keyedDecryptedEventDataSet.decryptedEventDataList.flatMap { plaintext ->
           CombinedEvents.parseFrom(plaintext.payload).serializedEventsList.map { serializedEvent ->

--- a/src/test/kotlin/org/wfanet/panelmatch/integration/FullWorkflowTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/integration/FullWorkflowTest.kt
@@ -37,6 +37,7 @@ import org.wfanet.panelmatch.common.compression.CompressionParametersKt.brotliCo
 import org.wfanet.panelmatch.common.compression.compressionParameters
 import org.wfanet.panelmatch.common.parseDelimitedMessages
 import org.wfanet.panelmatch.common.toDelimitedByteString
+import org.wfanet.panelmatch.integration.testing.TEST_PADDING_NONCE_PREFIX
 import org.wfanet.panelmatch.integration.testing.parsePlaintextResults
 
 private val PLAINTEXT_JOIN_KEYS = joinKeyAndIdCollection {
@@ -122,5 +123,13 @@ class FullWorkflowTest : AbstractInProcessPanelMatchIntegrationTest() {
       )
 
     assertThat(decryptedEvents).hasSize(3) // 1 padding nonce expected
+
+    val paddingNonce = decryptedEvents.firstOrNull { it.first.isEmpty() }
+    assertNotNull(paddingNonce)
+    assertThat(paddingNonce.second).hasSize(1)
+
+    val paddingNonceValue = paddingNonce.second.single()
+    assertThat(paddingNonceValue).startsWith(TEST_PADDING_NONCE_PREFIX)
+    assertThat(paddingNonceValue.length).isAtLeast(TEST_PADDING_NONCE_PREFIX.length + 8)
   }
 }


### PR DESCRIPTION
This cleans up some of the hacks added in #314. However, to finish cleaning things up, a separate PR ought to  partition the query results into normal queries and padding queries and write them to separate outputs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/315)
<!-- Reviewable:end -->
