### PR TITLE
Ensure that JoinKeys and JoinKeyIdentifiers are distinct

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/DeterministicCommutativeCipherTask.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/DeterministicCommutativeCipherTask.kt
@@ -46,8 +46,13 @@ internal constructor(
     val cryptoKey = input.getValue(INPUT_CRYPTO_KEY_LABEL).toByteString()
     val serializedInputs = input.getValue(inputDataLabel).toByteString()
     val inputList = JoinKeyAndIdCollection.parseFrom(serializedInputs).joinKeyAndIdsList
+
     val joinKeys = inputList.map { it.joinKey.key }
+    require(joinKeys.toSet().size == joinKeys.size) { "JoinKeys are not distinct" }
+
     val joinKeyIds = inputList.map { it.joinKeyIdentifier }
+    require(joinKeyIds.toSet().size == joinKeyIds.size) { "JoinKeyIdentifiers are not distinct" }
+
     val results = operation(cryptoKey, joinKeys)
     val serializedOutput =
       joinKeyAndIdCollection {


### PR DESCRIPTION
This blunts a sharp edge where invalid inputs won't be detected until the end of the workflow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/318)
<!-- Reviewable:end -->
