### PR TITLE
Fix DecryptQueries issue with padding queries

### DIFF
--- a/src/main/cc/wfa/panelmatch/client/privatemembership/decrypt_query_results.cc
+++ b/src/main/cc/wfa/panelmatch/client/privatemembership/decrypt_query_results.cc
@@ -116,7 +116,12 @@ absl::StatusOr<DecryptQueryResultsResponse> DecryptQueryResults(
                    RemoveRlwe(request));
 
   // If this is for a padding query, don't attempt to remove AES or decompress.
-  if (request.decrypted_join_key().key().empty()) {
+  // TODO(efoxepstein@): padding queries should be signalled explicitly.
+  // Rather than detecting them based on the JKI, we should just have a boolean
+  // flag in `request`.
+  absl::string_view join_key_identifier = request.decrypted_join_key().key();
+  if (join_key_identifier.empty() ||
+      join_key_identifier.substr(0, 14) == "padding-query:") {
     DecryptQueryResultsResponse result;
     for (const ClientDecryptedQueryResult& client_decrypted_query_result :
          client_decrypt_queries_response.result()) {

--- a/src/main/kotlin/org/wfanet/panelmatch/client/privatemembership/PaddingQueries.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/privatemembership/PaddingQueries.kt
@@ -1,0 +1,42 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.privatemembership
+
+import com.google.protobuf.ByteString
+import com.google.protobuf.kotlin.toByteStringUtf8
+import java.util.UUID
+import org.wfanet.panelmatch.client.common.joinKeyIdentifierOf
+import org.wfanet.panelmatch.client.exchangetasks.JoinKeyIdentifier
+
+@Deprecated(
+  "Use a random (not empty) JoinKeyIdentifier instead",
+  replaceWith = ReplaceWith("makePaddingQueryJoinKeyIdentifier()")
+)
+val PADDING_QUERY_JOIN_KEY_IDENTIFIER = joinKeyIdentifierOf(ByteString.EMPTY)
+
+private val PADDING_QUERY_JOIN_KEY_IDENTIFIER_PREFIX = "padding-query:".toByteStringUtf8()
+
+/** Returns a [JoinKeyIdentifier] suitable for only padding queries. */
+fun makePaddingQueryJoinKeyIdentifier(): JoinKeyIdentifier {
+  return joinKeyIdentifierOf(
+    PADDING_QUERY_JOIN_KEY_IDENTIFIER_PREFIX.concat(UUID.randomUUID().toString().toByteStringUtf8())
+  )
+}
+
+/** Indicates whether the receiver corresponds to a padding query. */
+val JoinKeyIdentifier.isPaddingQuery: Boolean
+  get() =
+    this == PADDING_QUERY_JOIN_KEY_IDENTIFIER ||
+      id.startsWith(PADDING_QUERY_JOIN_KEY_IDENTIFIER_PREFIX)

--- a/src/main/kotlin/org/wfanet/panelmatch/client/privatemembership/testing/AbstractCreateQueriesTest.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/privatemembership/testing/AbstractCreateQueriesTest.kt
@@ -41,6 +41,7 @@ import org.wfanet.panelmatch.client.privatemembership.QueryId
 import org.wfanet.panelmatch.client.privatemembership.QueryIdAndId
 import org.wfanet.panelmatch.client.privatemembership.ShardId
 import org.wfanet.panelmatch.client.privatemembership.createQueries
+import org.wfanet.panelmatch.client.privatemembership.isPaddingQuery
 import org.wfanet.panelmatch.client.privatemembership.lookupKeyAndId
 import org.wfanet.panelmatch.common.beam.count
 import org.wfanet.panelmatch.common.beam.flatMap
@@ -254,6 +255,10 @@ abstract class AbstractCreateQueriesTest : BeamTestBase() {
         requireNotNull(queryIdAndIdsList.singleOrNull()) {
           "${queryIdAndIdsList.size} of queryIdAndIds for $key"
         }
+
+      if (queryIdAndId.joinKeyIdentifier.isPaddingQuery) {
+        return@join
+      }
 
       val panelistQuery =
         PanelistQuery(query.shardId, query.bucketId, queryIdAndId.joinKeyIdentifier)

--- a/src/main/kotlin/org/wfanet/panelmatch/integration/testing/WorkflowTestHelper.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/integration/testing/WorkflowTestHelper.kt
@@ -16,11 +16,15 @@ package org.wfanet.panelmatch.integration.testing
 
 import org.wfanet.panelmatch.client.eventpreprocessing.CombinedEvents
 import org.wfanet.panelmatch.client.privatemembership.KeyedDecryptedEventDataSet
-import org.wfanet.panelmatch.client.privatemembership.PADDING_QUERY_JOIN_KEY_IDENTIFIER
+import org.wfanet.panelmatch.client.privatemembership.isPaddingQuery
 
 const val TEST_PADDING_NONCE_PREFIX: String = "[Padding Nonce]"
 
-data class ParsedPlaintextResults(val joinKey: String, val plaintexts: List<String>)
+data class ParsedPlaintextResults(
+  val joinKey: String,
+  val isPaddingQuery: Boolean,
+  val plaintexts: List<String>
+)
 
 /**
  * Parses plaintext results from a [KeyedDecryptedEventDataSet] containing serialized
@@ -32,8 +36,9 @@ fun parsePlaintextResults(
   return combinedTexts.map { keyedDecryptedEventDataSet ->
     val keyAndId = keyedDecryptedEventDataSet.plaintextJoinKeyAndId
     val joinKey = requireNotNull(keyAndId.joinKey).key.toStringUtf8()
+    val isPaddingQuery = keyAndId.joinKeyIdentifier.isPaddingQuery
     val payload =
-      if (keyAndId.joinKeyIdentifier.id == PADDING_QUERY_JOIN_KEY_IDENTIFIER.id) {
+      if (isPaddingQuery) {
         val element = keyedDecryptedEventDataSet.decryptedEventDataList.single().payload
         listOf("$TEST_PADDING_NONCE_PREFIX ${element.toStringUtf8()}")
       } else {
@@ -43,6 +48,6 @@ fun parsePlaintextResults(
           }
         }
       }
-    ParsedPlaintextResults(joinKey = joinKey, plaintexts = payload)
+    ParsedPlaintextResults(joinKey = joinKey, isPaddingQuery = isPaddingQuery, plaintexts = payload)
   }
 }


### PR DESCRIPTION
Padding queries should use distinct JoinKeyIdentifiers. This is a first step toward implementing that by fixing a critical bottleneck in DecryptQueryResults.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/326)
<!-- Reviewable:end -->
