### PR TITLE
Fix ReadAsSingletonPCollection: avoid Create.ofProvider.

### DIFF
--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/ApacheBeamContextTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/ApacheBeamContextTest.kt
@@ -55,10 +55,7 @@ class ApacheBeamContextTest : BeamTestBase() {
   @Before
   fun setup() {
     val path = temporaryFolder.root.path
-    storageFactory =
-      object : StorageFactory {
-        override fun build(): StorageClient = FileSystemStorageClient(File(path))
-      }
+    storageFactory = StorageFactory { FileSystemStorageClient(File(path)) }
     storageClient = storageFactory.build()
   }
 
@@ -81,6 +78,8 @@ class ApacheBeamContextTest : BeamTestBase() {
 
     assertThat(context.readBlobAsPCollection(LABEL)).containsInAnyOrder(BLOB_CONTENTS)
     assertThat(context.readBlobAsView(LABEL)).containsInAnyOrder(BLOB_CONTENTS)
+
+    pipeline.run()
   }
 
   @Test


### PR DESCRIPTION
Create.ofProvider will execute the provider before the workflow starts; the contents of the resulting PCollection are serialized into the workflow description itself. This causes failures for some large files under some runners.

The fix is to read the file as part of the pipeline in a ParDo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/330)
<!-- Reviewable:end -->
