### PR TITLE
Remove unnecessary check in private membership decryption

### DIFF
--- a/src/main/cc/wfa/panelmatch/client/privatemembership/decrypt_query_results.cc
+++ b/src/main/cc/wfa/panelmatch/client/privatemembership/decrypt_query_results.cc
@@ -116,12 +116,8 @@ absl::StatusOr<DecryptQueryResultsResponse> DecryptQueryResults(
                    RemoveRlwe(request));
 
   // If this is for a padding query, don't attempt to remove AES or decompress.
-  // TODO(efoxepstein@): padding queries should be signalled explicitly.
-  // Rather than detecting them based on the JKI, we should just have a boolean
-  // flag in `request`.
-  absl::string_view join_key_identifier = request.decrypted_join_key().key();
-  if (join_key_identifier.empty() ||
-      join_key_identifier.substr(0, 14) == "padding-query:") {
+  absl::string_view join_key = request.decrypted_join_key().key();
+  if (join_key.empty()) {
     DecryptQueryResultsResponse result;
     for (const ClientDecryptedQueryResult& client_decrypted_query_result :
          client_decrypt_queries_response.result()) {


### PR DESCRIPTION
The previous code was erroneous: it interpreted a `JoinKey` as a `JoinKeyIdentifier`. There wasn't an actual bug, but it was misleading. This simplifies: padding queries can be detected by `JoinKey`s are empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/333)
<!-- Reviewable:end -->
