### PR TITLE
When possible skip intersection in IntersectValidateTask

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/IntersectValidateTask.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/IntersectValidateTask.kt
@@ -42,7 +42,7 @@ class IntersectValidateTask(
       "${currentData.size} ids were provided, which exceeds the limit of $maxSize"
     }
 
-    if (!isFirstExchange) {
+    if (!isFirstExchange && maximumNewItemsAllowed < maxSize) {
       val oldDataBytes = input.getValue("previous-data").toByteString()
       val oldData: Set<JoinKeyAndId> = parseJoinKeyAndIds(oldDataBytes)
       validateIntersection(currentData, oldData)


### PR DESCRIPTION
This adds a shortcut to improve performance and simplify: if the `maximumNewItemsAllowed` is at least the `maxSize` then `validateIntersection` will never throw. This allows us to skip a blob read and save some CPU cycles. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/334)
<!-- Reviewable:end -->
