### PR TITLE
Make ApacheBeamTask failures permanent.

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/ApacheBeamTask.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/ApacheBeamTask.kt
@@ -39,8 +39,12 @@ class ApacheBeamTask(
       ApacheBeamContext(pipeline, outputManifests, outputLabels, inputLabels, input, storageFactory)
     context.executeOnPipeline()
 
-    val finalState = pipeline.run().waitUntilFinish()
-    check(finalState == PipelineResult.State.DONE) { "Pipeline is in state $finalState" }
+    try {
+      val finalState = pipeline.run().waitUntilFinish()
+      check(finalState == PipelineResult.State.DONE) { "Pipeline is in state $finalState" }
+    } catch (e: Exception) {
+      throw ExchangeTaskFailedException.ofPermanent(e)
+    }
 
     return outputManifests.mapValues { flowOf(it.value.spec.toByteStringUtf8()) }
   }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskFailedException.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskFailedException.kt
@@ -1,0 +1,40 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.exchangetasks
+
+import org.wfanet.measurement.api.v2alpha.ExchangeStepAttempt.State
+
+/**
+ * Exception to be thrown by exchange tasks upon failure. Allows the task to specify [attemptState],
+ * for example if the attempt should result in a permanent step failure.
+ */
+class ExchangeTaskFailedException private constructor(cause: Throwable, val attemptState: State) :
+  Exception(cause) {
+  companion object {
+    /**
+     * Returns an [ExchangeTaskFailedException] with a transient [attemptState], allowing the step
+     * to retry.
+     */
+    fun ofTransient(cause: Throwable): ExchangeTaskFailedException =
+      ExchangeTaskFailedException(cause, State.FAILED)
+
+    /**
+     * Returns an [ExchangeTaskFailedException] with a permanent [attemptState], which will mark the
+     * entire exchange as failed.
+     */
+    fun ofPermanent(cause: Throwable): ExchangeTaskFailedException =
+      ExchangeTaskFailedException(cause, State.FAILED_STEP)
+  }
+}

--- a/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/testing/FakeExchangeTaskMapper.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks/testing/FakeExchangeTaskMapper.kt
@@ -15,62 +15,65 @@
 package org.wfanet.panelmatch.client.exchangetasks.testing
 
 import org.wfanet.panelmatch.client.common.ExchangeContext
+import org.wfanet.panelmatch.client.exchangetasks.ExchangeTask
 import org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskMapper
 
-class FakeExchangeTaskMapper : ExchangeTaskMapper() {
+class FakeExchangeTaskMapper(
+  private val createExchangeTask: (String) -> ExchangeTask = ::FakeExchangeTask
+) : ExchangeTaskMapper() {
   override suspend fun ExchangeContext.commutativeDeterministicEncrypt() =
-    FakeExchangeTask("commutative-deterministic-encrypt")
+    createExchangeTask("commutative-deterministic-encrypt")
 
   override suspend fun ExchangeContext.commutativeDeterministicDecrypt() =
-    FakeExchangeTask("commutative-deterministic-decrypt")
+    createExchangeTask("commutative-deterministic-decrypt")
 
   override suspend fun ExchangeContext.commutativeDeterministicReEncrypt() =
-    FakeExchangeTask("commutative-deterministic-re-encrypt")
+    createExchangeTask("commutative-deterministic-re-encrypt")
 
   override suspend fun ExchangeContext.generateCommutativeDeterministicEncryptionKey() =
-    FakeExchangeTask("generate-commutative-deterministic-encryption-key")
+    createExchangeTask("generate-commutative-deterministic-encryption-key")
 
-  override suspend fun ExchangeContext.preprocessEvents() = FakeExchangeTask("preprocess-events")
+  override suspend fun ExchangeContext.preprocessEvents() = createExchangeTask("preprocess-events")
 
   override suspend fun ExchangeContext.buildPrivateMembershipQueries() =
-    FakeExchangeTask("build-private-membership-queries")
+    createExchangeTask("build-private-membership-queries")
 
   override suspend fun ExchangeContext.executePrivateMembershipQueries() =
-    FakeExchangeTask("execute-private-membership-queries")
+    createExchangeTask("execute-private-membership-queries")
 
   override suspend fun ExchangeContext.decryptMembershipResults() =
-    FakeExchangeTask("decrypt-membership-results")
+    createExchangeTask("decrypt-membership-results")
 
   override suspend fun ExchangeContext.generateSerializedRlweKeyPair() =
-    FakeExchangeTask("generate-serialized-rlwe-key-pair")
+    createExchangeTask("generate-serialized-rlwe-key-pair")
 
   override suspend fun ExchangeContext.generateExchangeCertificate() =
-    FakeExchangeTask("generate-exchange-certificate")
+    createExchangeTask("generate-exchange-certificate")
 
   override suspend fun ExchangeContext.generateLookupKeys() =
-    FakeExchangeTask("generate-lookup-keys")
+    createExchangeTask("generate-lookup-keys")
 
   override suspend fun ExchangeContext.intersectAndValidate() =
-    FakeExchangeTask("intersect-and-validate")
+    createExchangeTask("intersect-and-validate")
 
-  override suspend fun ExchangeContext.input() = FakeExchangeTask("input")
+  override suspend fun ExchangeContext.input() = createExchangeTask("input")
 
   override suspend fun ExchangeContext.copyFromPreviousExchange() =
-    FakeExchangeTask("copy-from-previous-exchange")
+    createExchangeTask("copy-from-previous-exchange")
 
   override suspend fun ExchangeContext.copyFromSharedStorage() =
-    FakeExchangeTask("copy-from-shared-storage")
+    createExchangeTask("copy-from-shared-storage")
 
   override suspend fun ExchangeContext.copyToSharedStorage() =
-    FakeExchangeTask("copy-to-shared-storage")
+    createExchangeTask("copy-to-shared-storage")
 
-  override suspend fun ExchangeContext.hybridEncrypt() = FakeExchangeTask("hybird-encrypt")
+  override suspend fun ExchangeContext.hybridEncrypt() = createExchangeTask("hybird-encrypt")
 
-  override suspend fun ExchangeContext.hybridDecrypt() = FakeExchangeTask("hybrid-decrypt")
+  override suspend fun ExchangeContext.hybridDecrypt() = createExchangeTask("hybrid-decrypt")
 
   override suspend fun ExchangeContext.generateHybridEncryptionKeyPair() =
-    FakeExchangeTask("generate-hybrid-encryption-key-pair")
+    createExchangeTask("generate-hybrid-encryption-key-pair")
 
   override suspend fun ExchangeContext.generateRandomBytes() =
-    FakeExchangeTask("generate-random-bytes")
+    createExchangeTask("generate-random-bytes")
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutor.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/launcher/ExchangeTaskExecutor.kt
@@ -25,6 +25,7 @@ import org.wfanet.measurement.storage.StorageClient
 import org.wfanet.measurement.storage.StorageClient.Blob
 import org.wfanet.panelmatch.client.common.ExchangeContext
 import org.wfanet.panelmatch.client.exchangetasks.ExchangeTask
+import org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskFailedException
 import org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskMapper
 import org.wfanet.panelmatch.client.launcher.ExchangeStepValidator.ValidatedExchangeStep
 import org.wfanet.panelmatch.client.logger.TaskLog
@@ -61,7 +62,12 @@ class ExchangeTaskExecutor(
         context.tryExecute()
       } catch (e: Exception) {
         logger.addToTaskLog(e, Level.SEVERE)
-        markAsFinished(attemptKey, ExchangeStepAttempt.State.FAILED)
+        val attemptState =
+          when (e) {
+            is ExchangeTaskFailedException -> e.attemptState
+            else -> ExchangeStepAttempt.State.FAILED
+          }
+        markAsFinished(attemptKey, attemptState)
         throw e
       }
     }

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/BUILD.bazel
@@ -20,6 +20,19 @@ kt_jvm_test(
 )
 
 kt_jvm_test(
+    name = "ExchangeTaskFailedExceptionTest",
+    timeout = "short",
+    srcs = ["ExchangeTaskFailedExceptionTest.kt"],
+    test_class = "org.wfanet.panelmatch.client.exchangetasks.ExchangeTaskFailedExceptionTest",
+    deps = [
+        "//src/main/kotlin/org/wfanet/panelmatch/client/exchangetasks",
+        "//src/main/proto/wfa/measurement/api/v2alpha:exchange_step_attempt_kt_jvm_proto",
+        "@wfa_common_jvm//imports/java/com/google/common/truth",
+        "@wfa_common_jvm//imports/java/org/junit",
+    ],
+)
+
+kt_jvm_test(
     name = "HybridCryptorTasksTest",
     timeout = "short",
     srcs = ["HybridCryptorTasksTest.kt"],

--- a/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskFailedExceptionTest.kt
+++ b/src/test/kotlin/org/wfanet/panelmatch/client/exchangetasks/ExchangeTaskFailedExceptionTest.kt
@@ -1,0 +1,37 @@
+// Copyright 2022 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.wfanet.panelmatch.client.exchangetasks
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.wfanet.measurement.api.v2alpha.ExchangeStepAttempt.State
+
+@RunWith(JUnit4::class)
+class ExchangeTaskFailedExceptionTest {
+
+  @Test
+  fun ofTransientHasAttemptStateFailed() {
+    assertThat(ExchangeTaskFailedException.ofTransient(IllegalStateException()).attemptState)
+      .isEqualTo(State.FAILED)
+  }
+
+  @Test
+  fun ofPermanentHasAttemptStateFailedStep() {
+    assertThat(ExchangeTaskFailedException.ofPermanent(IllegalStateException()).attemptState)
+      .isEqualTo(State.FAILED_STEP)
+  }
+}


### PR DESCRIPTION
Repeated failures on Beam tasks can quickly rack up a large bill. As a safeguard, Beam task failures can be marked as permanent, causing all execution on a given exchange to halt until participants can deliver a fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/340)
<!-- Reviewable:end -->
