### PR TITLE
Use breakFusion() judiciously to reduce costs.

### DIFF
--- a/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/PreprocessEvents.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/eventpreprocessing/PreprocessEvents.kt
@@ -24,7 +24,6 @@ import org.wfanet.panelmatch.client.privatemembership.DatabaseEntry
 import org.wfanet.panelmatch.client.privatemembership.databaseEntry
 import org.wfanet.panelmatch.client.privatemembership.encryptedEntry
 import org.wfanet.panelmatch.client.privatemembership.lookupKey
-import org.wfanet.panelmatch.common.beam.breakFusion
 import org.wfanet.panelmatch.common.beam.groupByKey
 import org.wfanet.panelmatch.common.beam.kvOf
 import org.wfanet.panelmatch.common.beam.map
@@ -98,6 +97,5 @@ class PreprocessEventsTransform(
           this.encryptedEntry = encryptedEntry { data = it.value }
         }
       }
-      .breakFusion("Break Fusion After Preprocess Events")
   }
 }

--- a/src/main/kotlin/org/wfanet/panelmatch/client/privatemembership/CreateQueries.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/privatemembership/CreateQueries.kt
@@ -35,7 +35,6 @@ import org.wfanet.panelmatch.client.common.queryIdOf
 import org.wfanet.panelmatch.client.common.shardIdOf
 import org.wfanet.panelmatch.client.common.unencryptedQueryOf
 import org.wfanet.panelmatch.client.exchangetasks.JoinKeyIdentifier
-import org.wfanet.panelmatch.common.beam.breakFusion
 import org.wfanet.panelmatch.common.beam.createSequence
 import org.wfanet.panelmatch.common.beam.filter
 import org.wfanet.panelmatch.common.beam.flatten
@@ -130,7 +129,6 @@ private class CreateQueries(
     return PCollectionList.of(queries)
       .and(missingQueries)
       .flatten("Flatten queries+missingQueries")
-      .breakFusion("Break fusion before EqualizeQueriesPerShardFn")
       .parDo(
         EqualizeQueriesPerShardFn(totalQueriesPerShard, paddingNonceBucket),
         name = "Equalize Queries per Shard"
@@ -197,14 +195,11 @@ private class CreateQueries(
     unencryptedQueries: PCollection<KV<ShardId, List<FullUnencryptedQuery>>>,
     privateMembershipKeys: PCollectionView<AsymmetricKeyPair>
   ): PCollection<EncryptedQueryBundle> {
-    return unencryptedQueries
-      .breakFusion("Break Fusion Before Encrypt Queries")
-      .apply(
-        "Encrypt Queries per Shard",
-        ParDo.of(EncryptQueriesFn(this.privateMembershipCryptor, privateMembershipKeys))
-          .withSideInputs(privateMembershipKeys)
-      )
-      .breakFusion("Break Fusion After Encrypt Queries")
+    return unencryptedQueries.apply(
+      "Encrypt Queries per Shard",
+      ParDo.of(EncryptQueriesFn(this.privateMembershipCryptor, privateMembershipKeys))
+        .withSideInputs(privateMembershipKeys)
+    )
   }
 
   companion object {

--- a/src/main/kotlin/org/wfanet/panelmatch/client/privatemembership/DecryptQueryResults.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/privatemembership/DecryptQueryResults.kt
@@ -34,7 +34,6 @@ import org.wfanet.panelmatch.client.exchangetasks.JoinKey
 import org.wfanet.panelmatch.client.exchangetasks.JoinKeyAndId
 import org.wfanet.panelmatch.client.exchangetasks.JoinKeyIdentifier
 import org.wfanet.panelmatch.client.exchangetasks.joinKeyAndId
-import org.wfanet.panelmatch.common.beam.breakFusion
 import org.wfanet.panelmatch.common.beam.filter
 import org.wfanet.panelmatch.common.beam.flatten
 import org.wfanet.panelmatch.common.beam.groupByKey
@@ -134,7 +133,6 @@ class DecryptQueryResults(
       PCollection<KV<JoinKeyIdentifier, List<@JvmWildcard Plaintext>>> =
       decryptedJoinKeyKeyedByQueryId
         .oneToOneJoin(groupedEncryptedQueryResults, name = "Join JoinKeys+QueryResults")
-        .breakFusion("BreakFusion before DecryptResultsFnRequests")
         .apply(
           "Make DecryptResultsFnRequests",
           ParDo.of(
@@ -147,7 +145,6 @@ class DecryptQueryResults(
             )
             .withSideInputs(privateMembershipKeys, compressionParameters)
         )
-        .breakFusion("BreakFusion before Decrypt")
         .parDo(DecryptResultsFn(queryResultsDecryptor), name = "Decrypt")
         .setCoder(plaintextListCoder)
 

--- a/src/main/kotlin/org/wfanet/panelmatch/client/privatemembership/EvaluateQueries.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/client/privatemembership/EvaluateQueries.kt
@@ -29,7 +29,6 @@ import org.apache.beam.sdk.values.PCollectionView
 import org.apache.beam.sdk.values.TupleTag
 import org.wfanet.panelmatch.client.common.bucketOf
 import org.wfanet.panelmatch.client.common.databaseShardOf
-import org.wfanet.panelmatch.common.beam.breakFusion
 import org.wfanet.panelmatch.common.beam.keyBy
 import org.wfanet.panelmatch.common.beam.kvOf
 import org.wfanet.panelmatch.common.beam.map
@@ -50,7 +49,6 @@ fun evaluateQueries(
       "Evaluate Queries",
       EvaluateQueries(parameters, queryEvaluator, serializedPublicKey, paddingNonces)
     )
-    .breakFusion("Break Fusion After Evaluate Queries")
 }
 
 private class EvaluateQueries(

--- a/src/main/kotlin/org/wfanet/panelmatch/common/beam/WriteShardedData.kt
+++ b/src/main/kotlin/org/wfanet/panelmatch/common/beam/WriteShardedData.kt
@@ -84,7 +84,6 @@ class WriteShardedData<T : Message>(
       PCollectionList.of(groupedData)
         .and(missingFiles)
         .flatten("Flatten groupedData+missingFiles")
-        .breakFusion("Break Fusion Before WriteFilesFn")
         .setCoder(groupedData.coder)
         .apply("Write $fileSpec", ParDo.of(WriteFilesFn(fileSpec, storageFactory)))
 


### PR DESCRIPTION
This function was initially introduced to encourage the job runner to scale the number of workers between stages, by materializing the output of one stage so that it could be processed by a different number of workers. However, materializing intermediate results and shuffling the data to different workers incurs a massive cost (at least, on GCP). It has been observed that this shuffle cost is the single largest line item for GCP-run exchanges, coming in at around 5x the cost of the next largest line item (which is vCPU usage).

In addition, the --dataflow-max-num-workers flag, which was added after breakFusion(), appears to accomplish the same goal of prompting worker scaling (in most cases), but without the associated shuffle cost.

For these reasons, this PR removes breakFusion() from almost all locations. The only locations where it remains are in CopyToSharedStorageBeamTask and CopyFromSharedStorageBeamTask, because it was observed that without breakFusion(), these do not scale workers (also, their total combined shuffle size is <50MiB).

This has been tested multiple times on GCP with an exchange of 1B synthetic EDP events and 800K MP queries. The impact on the MP alone was the following:

* Reduced per exchange shuffle usage from 46TiB to 5TiB.
* Reduced the sum of time in Beam tasks from 131m to 75m.
* Peak worker count was 25% less after removing breakFusion().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/panel-exchange-client/344)
<!-- Reviewable:end -->
