### PR TITLE
Hardcode AWS default algorithm as RSA.

### DIFF
--- a/src/main/k8s/dev/example_daemon_aws.cue
+++ b/src/main/k8s/dev/example_daemon_aws.cue
@@ -59,9 +59,10 @@ import "strings"
 	args: [
 		"--id=\(_partyId)",
 		"--party-type=\(partyType)",
+		"--storage-signing-algorithm=RSA",
+		"--tink-key-uri=\(tinkKeyUri)",
 		"--tls-cert-file=\(clientTls.certFile)",
 		"--tls-key-file=\(clientTls.keyFile)",
-		"--tink-key-uri=\(tinkKeyUri)",
 	]
 }
 


### PR DESCRIPTION
It is currently unset, but this removes a pitfall in setup.